### PR TITLE
changed SHELL to /bin/bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GO ?= go
-SHELL = sh
+SHELL = /bin/bash
 BIN_DIR = ./build/bin
 RAZOR = ${BIN_DIR}/razor
 

--- a/generate-bindings.sh
+++ b/generate-bindings.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 set -e -o pipefail
 


### PR DESCRIPTION
fixes #52 
- changed SHELL to /bin/bash in order to generate bindings and build from scratch.