### PR TITLE
Optimization for RPC calls in vote.go

### DIFF
--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -111,8 +111,7 @@ func handleBlock(client *ethclient.Client, account types.Account, blockNumber *b
 			break
 		}
 		_committedData = data
-		time.Sleep(time.Duration(core.StateLength * 2) * time.Second)
-
+		utils.WaitTillNextState()
 	case 1:
 		lastReveal := staker.EpochLastRevealed
 		if _committedData == nil || (lastReveal != nil && lastReveal.Cmp(epoch) >= 0) {
@@ -127,8 +126,7 @@ func handleBlock(client *ethclient.Client, account types.Account, blockNumber *b
 			break
 		}
 		Reveal(client, _committedData, secret, account, account.Address, config)
-		time.Sleep(time.Duration(core.StateLength * 2) * time.Second)
-
+		utils.WaitTillNextState()
 	case 2:
 		lastProposal := getLastProposedEpoch(client, blockNumber, stakerId)
 		if lastProposal != nil && lastProposal.Cmp(epoch) >= 0 {
@@ -137,15 +135,14 @@ func handleBlock(client *ethclient.Client, account types.Account, blockNumber *b
 		lastProposal = epoch
 		log.Info("Proposing block....")
 		Propose(client, account, config, stakerId, epoch)
-		time.Sleep(time.Duration(core.StateLength * 2) * time.Second)
-
+		utils.WaitTillNextState()
 	case 3:
 		if lastVerification != nil && lastVerification.Cmp(epoch) >= 0 {
 			break
 		}
 		lastVerification = epoch
 		HandleDispute(client, config, account, epoch)
-		time.Sleep(time.Duration(core.StateLength * 2) * time.Second)
+		utils.WaitTillNextState()
 	}
 
 }

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -111,7 +111,7 @@ func handleBlock(client *ethclient.Client, account types.Account, blockNumber *b
 			break
 		}
 		_committedData = data
-		break
+		time.Sleep(time.Duration(core.StateLength * 2) * time.Second)
 
 	case 1:
 		lastReveal := staker.EpochLastRevealed
@@ -127,7 +127,7 @@ func handleBlock(client *ethclient.Client, account types.Account, blockNumber *b
 			break
 		}
 		Reveal(client, _committedData, secret, account, account.Address, config)
-		break
+		time.Sleep(time.Duration(core.StateLength * 2) * time.Second)
 
 	case 2:
 		lastProposal := getLastProposedEpoch(client, blockNumber, stakerId)
@@ -137,7 +137,7 @@ func handleBlock(client *ethclient.Client, account types.Account, blockNumber *b
 		lastProposal = epoch
 		log.Info("Proposing block....")
 		Propose(client, account, config, stakerId, epoch)
-		break
+		time.Sleep(time.Duration(core.StateLength * 2) * time.Second)
 
 	case 3:
 		if lastVerification != nil && lastVerification.Cmp(epoch) >= 0 {
@@ -145,7 +145,7 @@ func handleBlock(client *ethclient.Client, account types.Account, blockNumber *b
 		}
 		lastVerification = epoch
 		HandleDispute(client, config, account, epoch)
-		break
+		time.Sleep(time.Duration(core.StateLength * 2) * time.Second)
 	}
 
 }

--- a/utils/array.go
+++ b/utils/array.go
@@ -59,7 +59,7 @@ func ConvertToBigIntArray(data []string) []*big.Int {
 	return bigIntArray
 }
 
-func CalculateSumOfArray(data []*big.Int) *big.Int {
+func CalculateSumOfBigIntArray(data []*big.Int) *big.Int {
 	sum := big.NewInt(0)
 	for _, datum := range data {
 		sum.Add(sum, datum)

--- a/utils/common.go
+++ b/utils/common.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"github.com/briandowns/spinner"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	log "github.com/sirupsen/logrus"
@@ -100,4 +101,13 @@ func CheckError(msg string, err error) {
 	if err != nil {
 		log.Fatal(msg + err.Error())
 	}
+}
+
+func WaitTillNextState() {
+	s := spinner.New(spinner.CharSets[11], 100 * time.Millisecond)
+	s.Start()
+	s.Color("bgBlack", "bold", "fgYellow")
+	s.Prefix = "Waiting for the next state "
+	time.Sleep(time.Duration((core.StateLength - 10) * 2) * time.Second)
+	s.Stop()
 }

--- a/utils/common.go
+++ b/utils/common.go
@@ -48,8 +48,8 @@ func GetDelayedState(client *ethclient.Client, buffer int32) (int64, error) {
 	if err != nil {
 		return -1, err
 	}
-	lowerLimit := (core.StateLength * uint64(buffer))/100
-	upperLimit := core.StateLength - (core.StateLength * uint64(buffer))/100
+	lowerLimit := (core.StateLength * uint64(buffer)) / 100
+	upperLimit := core.StateLength - (core.StateLength*uint64(buffer))/100
 	if blockNumber%(core.StateLength) > upperLimit || blockNumber%(core.StateLength) < lowerLimit {
 		return -1, nil
 	}
@@ -68,7 +68,7 @@ func checkTransactionReceipt(client *ethclient.Client, _txHash string) int {
 
 func WaitForBlockCompletion(client *ethclient.Client, hashToRead string) int {
 	timeout := core.StateLength * 2
-	for start := time.Now(); time.Since(start) < time.Duration(timeout)*time.Second ; {
+	for start := time.Now(); time.Since(start) < time.Duration(timeout)*time.Second; {
 		log.Info("Checking if transaction is mined....\n")
 		transactionStatus := checkTransactionReceipt(client, hashToRead)
 		if transactionStatus == 0 {
@@ -104,10 +104,10 @@ func CheckError(msg string, err error) {
 }
 
 func WaitTillNextState() {
-	s := spinner.New(spinner.CharSets[11], 100 * time.Millisecond)
+	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 	s.Start()
 	s.Color("bgBlack", "bold", "fgYellow")
 	s.Prefix = "Waiting for the next state "
-	time.Sleep(time.Duration((core.StateLength - 10) * 2) * time.Second)
+	time.Sleep(time.Duration((core.StateLength-10)*2) * time.Second)
 	s.Stop()
 }

--- a/utils/math.go
+++ b/utils/math.go
@@ -106,7 +106,7 @@ func performAggregation(data []*big.Int, aggregationMethod uint32) (*big.Int, er
 		sortutil.BigIntSlice.Sort(data)
 		return data[len(data)/2], nil
 	case 2:
-		sum := CalculateSumOfArray(data)
+		sum := CalculateSumOfBigIntArray(data)
 		return sum.Div(sum, big.NewInt(int64(len(data)))), nil
 	}
 	return nil, errors.New("invalid aggregation method")


### PR DESCRIPTION
Currently, we fetch a block every 3 secs while voting. This increases the number of RPC calls and is not feasible. Instead of doing that, this fix aims at fetching the block once in every state.  This will reduce the number of RPC calls drastically and optimise the voting process.

Closes #49 