### PR TITLE
Create new config.sh to set config properly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,11 @@ fetch_bindings:
 install_razor:
 	@echo "Installing razor node...."
 	${GO} build -o ./build/bin/razor main.go
-	@echo "Razor node installed. \n"
+	@echo "Razor node installed."
+	@echo ""
 
 set_config:
-	@echo "Enter provider: "; \
-	read PROVIDER; \
-	echo "Enter gas multiplier value: "; \
-	read GAS_MULTIPLIER; \
-	echo "Enter buffer percent: "; \
-    read BUFFER_PERCENT; \
-    echo "\n"; \
-    echo "Setting initial config..."; \
-    ${RAZOR} setconfig -p $${PROVIDER} -g $${GAS_MULTIPLIER} -b $${BUFFER_PERCENT}
-	@echo "Setup done"
+	@echo "Setup initial config"
+	@${SHELL} config.sh
+	@echo ""
+	@echo "Razor node is set up and ready to use"

--- a/cmd/setconfig.go
+++ b/cmd/setconfig.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"log"
 	"razor/utils"
 )
 
@@ -25,6 +25,12 @@ Setting the gas multiplier value enables the CLI to multiply the gas with that v
 		}
 		if bufferPercent != 0 {
 			viper.Set("buffer", bufferPercent)
+		}
+		if provider == "" && gasMultiplier == -1 && bufferPercent == 0 {
+			viper.Set("provider", "http://127.0.0.1:8545")
+			viper.Set("gasmultiplier", 1.0)
+			viper.Set("buffer", 30)
+			log.Info("Config values set to default. Use setconfig to modify the values.")
 		}
 		path := utils.GetDefaultPath() + "/razor.yaml"
 		err := viper.WriteConfigAs(path)

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+BIN_DIR=./build/bin
+RAZOR=${BIN_DIR}/razor
+
+read -rp "Provider: (http://127.0.0.1:8545) " PROVIDER
+if [ -z "$PROVIDER" ];
+then
+  PROVIDER="http://127.0.0.1:8545"
+fi
+
+read -rp "Gas Multiplier: (1.0) " GASMULTIPLIER
+if [ -z "$GASMULTIPLIER" ];
+then
+  GASMULTIPLIER=1.0
+fi
+
+read -rp "Buffer Percent: (20) " BUFFER
+if [ -z "$BUFFER" ];
+then
+  BUFFER=20
+fi
+
+$RAZOR setconfig -p $PROVIDER -b $BUFFER -g $GASMULTIPLIER


### PR DESCRIPTION
`config.sh` reads user input to set config parameters, in case the user doesn't enter anything, the default value mentioned is used.

Closes #64 

Signed-off-by: Ashish Mishra <ashish10677@gmail.com>