### PR TITLE
Added test file for cmd/stake.go

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -83,7 +83,7 @@ func Commit(client *ethclient.Client, data []*big.Int, secret []byte, account ty
 
 	log.Info("Commitment sent...\nTxn hash: ", txn.Hash())
 
-	if utils.WaitForBlockCompletion(client, fmt.Sprintf("%s", txn.Hash())) == 0 {
+	if utils.WaitForBlockCompletion(client, fmt.Sprintf("%s", txn.Hash())) != nil {
 		log.Error("Commit failed....")
 	}
 	return nil

--- a/cmd/stake.go
+++ b/cmd/stake.go
@@ -52,7 +52,7 @@ var stakeCmd = &cobra.Command{
 	},
 }
 
-func approve(txnArgs types.TransactionOptions) {
+func approve(txnArgs types.TransactionOptions) int {
 	tokenManager := utils.GetTokenManager(txnArgs.Client)
 	opts := utils.GetOptions(false, txnArgs.AccountAddress, "")
 	allowance, err := tokenManager.Allowance(&opts, common.HexToAddress(txnArgs.AccountAddress), common.HexToAddress(core.StakeManagerAddress))
@@ -61,6 +61,7 @@ func approve(txnArgs types.TransactionOptions) {
 	}
 	if allowance.Cmp(txnArgs.Amount) >= 0 {
 		log.Info("Sufficient allowance, no need to increase")
+		return 1
 	} else {
 		log.Info("Sending Approve transaction...")
 		txnOpts := utils.GetTxnOpts(txnArgs)
@@ -70,7 +71,8 @@ func approve(txnArgs types.TransactionOptions) {
 		}
 		log.Info("Approve transaction sent...\nTxn Hash: ", txn.Hash())
 		log.Info("Waiting for transaction to be mined....")
-		utils.WaitForBlockCompletion(txnArgs.Client, fmt.Sprintf("%s", txn.Hash()))
+		approvedStatus := utils.WaitForBlockCompletion(txnArgs.Client, fmt.Sprintf("%s", txn.Hash()))
+		return approvedStatus
 	}
 }
 

--- a/cmd/stake_test.go
+++ b/cmd/stake_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	log "github.com/sirupsen/logrus"
+	"math/big"
+	"razor/core"
+	"razor/core/types"
+	"razor/utils"
+	"testing"
+)
+
+func getTransactionArgs() types.TransactionOptions{
+	password := "12345"
+	address := "0x53baCf1E1C6E14BB5700178Acf426dF6f0d5A949" // Provide your address for testing
+	provider := "http://127.0.0.1:8545/"
+	client, err := ethclient.Dial(provider)
+	if err != nil {
+		log.Fatal("Error in connecting...\n", err)
+	}
+	log.Info("Connected to: ", provider)
+	if err != nil {
+		log.Fatal(err)
+	}
+	balance, err := utils.FetchBalance(client, address)
+	amount := "1000"
+	amountInWei := utils.GetAmountWithChecks(amount, balance)
+
+	txnArgs := types.TransactionOptions{
+		Client:         client,
+		AccountAddress: address,
+		Amount:         amountInWei,
+		Password:       password,
+		ChainId:        big.NewInt(1337),
+		GasMultiplier:  10,
+	}
+	return txnArgs
+}
+
+func Test_approve(t *testing.T) {
+	txnArgs := getTransactionArgs()
+
+	t.Run("Test1: Staker is able to approve", func(t *testing.T) {
+		approvedStatus := approve(txnArgs)
+		if got := approvedStatus; got != 1 {
+			t.Errorf("Staker is not able to approve")
+		}
+	})
+	t.Run("Test2: Sufficient allowance, no need to increase approved amount ", func(t *testing.T) {
+		approvedStatus := approve(txnArgs)
+		if got := approvedStatus; got != 1 {
+			t.Errorf("No Sufficient allowance, increase the amount ")
+		}
+	})
+	t.Run("Test3: Allowance of number of razors is set correctly after approve", func(t *testing.T) {
+		tokenManager := utils.GetTokenManager(txnArgs.Client)
+		opts := utils.GetOptions(false, txnArgs.AccountAddress, "")
+		allowance, _ := tokenManager.Allowance(&opts, common.HexToAddress(txnArgs.AccountAddress), common.HexToAddress(core.StakeManagerAddress))
+
+		if got := allowance; got.Cmp(txnArgs.Amount) != 1 && got.Cmp(txnArgs.Amount) != 0 {
+			t.Errorf("Amount of razor's approved are less than the required amount of razor's to be sent")
+		}
+	})
+}
+
+func Test_stakeCoins(t *testing.T) {
+	txnArgs := getTransactionArgs()
+	opts := utils.GetOptions(false, txnArgs.AccountAddress, "")
+	stakeManager:= utils.GetStakeManager(txnArgs.Client)
+
+	type args struct {
+		txnOpts types.TransactionOptions
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "Test1: Staker is able to stake for the first time.",
+			args: args{
+				txnOpts: getTransactionArgs(),
+			},
+		},
+		{
+			name: "Test2: Staker is able to stake again",
+			args: args{
+				txnOpts: getTransactionArgs(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stakerId,_ := stakeManager.GetStakerId(&opts, common.HexToAddress(txnArgs.AccountAddress))
+
+			if stakerId.Cmp(big.NewInt(0)) == 0 {
+				approve(txnArgs)
+				stakeCoins(txnArgs)
+
+				newStakerID,_ := stakeManager.GetStakerId(&opts, common.HexToAddress(txnArgs.AccountAddress))
+				staker,_ := utils.GetStaker(txnArgs.Client, txnArgs.AccountAddress, newStakerID)
+				expectedStake := big.NewInt(0)
+				expectedStake.Add(expectedStake, txnArgs.Amount)
+				newStake := staker.Stake
+
+				if got := newStake; got.Cmp(expectedStake) != 0 {
+					t.Errorf("Error in Staking for the first time")
+				}
+			}
+			if stakerId.Cmp(big.NewInt(0)) != 0 {
+				staker,_ := utils.GetStaker(txnArgs.Client, txnArgs.AccountAddress, stakerId)
+				previousStake := staker.Stake
+
+				approve(txnArgs)
+				stakeCoins(txnArgs)
+				staker1,_ := utils.GetStaker(txnArgs.Client, txnArgs.AccountAddress, stakerId)
+				newStake := staker1.Stake
+
+				expectedStake := big.NewInt(0)
+				expectedStake.Add(previousStake, txnArgs.Amount)
+
+				if got := newStake; got.Cmp(expectedStake) != 0 {
+					t.Errorf("Error in Staking the stake amount")
+				}
+			}
+		})
+	}
+
+}
+

--- a/utils/common.go
+++ b/utils/common.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"os"
 	"razor/core"
@@ -64,22 +65,22 @@ func checkTransactionReceipt(client *ethclient.Client, _txHash string) int {
 	return int(tx.Status)
 }
 
-func WaitForBlockCompletion(client *ethclient.Client, hashToRead string) int {
+func WaitForBlockCompletion(client *ethclient.Client, hashToRead string) error {
 	timeout := core.StateLength * 2
 	for start := time.Now(); time.Since(start) < time.Duration(timeout)*time.Second; {
 		log.Info("Checking if transaction is mined....\n")
 		transactionStatus := checkTransactionReceipt(client, hashToRead)
 		if transactionStatus == 0 {
 			log.Info("Transaction mining unsuccessful")
-			return 0
+			return errors.New("transaction mining unsuccessful")
 		} else if transactionStatus == 1 {
 			log.Info("Transaction mined successfully\n")
-			return 1
+			return nil
 		}
 		time.Sleep(3 * time.Second)
 	}
 	log.Info("Timeout Passed")
-	return 0
+	return errors.New("timeout passed")
 }
 
 func GetMerkleTree(data []*big.Int) (*merkletree.MerkleTree, error) {


### PR DESCRIPTION
resolve #69 
- Test file created for cmd/stake.go
- Includes tests for approve and stakeCoins function

Setting Up Testing Environment:
- Start ganache-cli with a menmonic
`ganache-cli -a 15 -b 2 -d -m "slide margin library genuine elbow enhance acoustic genre install wing angry click"
`
- Deploy the contracts on ganache
`npm run deploy:ganache
`
- Get the faucets in accounts from which transactions would be done.
- Replace the deployed addresses of contracts in razor-go/core/constants.go with the new deployed addresses on ganache. 
- Run `npm run build-all` to build razor-go and get the bindings.
- Provide your address for testing in cmd/stake_test.go and start testing functions by running the test files.