### PR TITLE
Remove fee from createJob and createCollection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,28 +140,28 @@ $ ./razor transfer --amount 100 --to 0x91b1E6488307450f4c0442a1c35Bc314A505293e 
 You can create new jobs using `creteJob` command. This command will work only for admins.
 
 ```
-$ ./razor createJob --url <URL> --selector <selector_in_json_selector_format> --name <name> --fee <fee_to_lock> --address <address>
+$ ./razor createJob --url <URL> --selector <selector_in_json_selector_format> --name <name> --address <address> --repeat <true_or_false>
 ```
 
 Example:
 ```
-$ ./razor createJob --url https://www.alphavantage.co/query\?function\=GLOBAL_QUOTE\&symbol\=MSFT\&apikey\=demo --selector '[`Global Quote`][`05. price`]" --fee 100 --name msft --repeat false --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c
+$ ./razor createJob --url https://www.alphavantage.co/query\?function\=GLOBAL_QUOTE\&symbol\=MSFT\&apikey\=demo --selector '[`Global Quote`][`05. price`]" --name msft --repeat false --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c
 ```
 OR
 ```
-$  ./razor createJob --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c -f 100 -n ethusd -r true -s last -u https://api.gemini.com/v1/pubticker/ethusd
+$  ./razor createJob --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c -n ethusd -r true -s last -u https://api.gemini.com/v1/pubticker/ethusd
 ```
 
 ### Create Collection
 You can create new collections using `creteCollection` command. This command will work only for admins.
 
 ```
-$ ./razor createCollection --name <collection_name> --fee <fee_to_lock> --address <address> --jobIds <list_of_job_ids> --aggregation <aggregation_method>
+$ ./razor createCollection --name <collection_name> --address <address> --jobIds <list_of_job_ids> --aggregation <aggregation_method>
 ```
 
 Example:
 ```
-$ ./razor createCollection --name btcCollectionMean -f 100 --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --jobIds 1,2 --aggregation 2
+$ ./razor createCollection --name btcCollectionMean --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --jobIds 1,2 --aggregation 2
 ```
 
 ### Add Job to Collection

--- a/cmd/createCollection.go
+++ b/cmd/createCollection.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"math/big"
 	"razor/core"
 	"razor/core/types"
 	"razor/utils"
@@ -23,24 +22,17 @@ var createCollectionCmd = &cobra.Command{
 		password := utils.PasswordPrompt()
 
 		name, _ := cmd.Flags().GetString("name")
-		fee, _ := cmd.Flags().GetString("fee")
 		address, _ := cmd.Flags().GetString("address")
 		jobIds, _ := cmd.Flags().GetStringSlice("jobIds")
 		aggregation, _ := cmd.Flags().GetUint32("aggregation")
 
 		client := utils.ConnectToClient(config.Provider)
 
-		feeInBigInt, ok := new(big.Int).SetString(fee, 10)
-		if !ok {
-			log.Fatal("SetString: error")
-		}
-
 		jobIdsInBigInt := utils.ConvertToBigIntArray(jobIds)
 
 		txnOpts := utils.GetTxnOpts(types.TransactionOptions{
 			Client:         client,
 			Password:       password,
-			EtherValue:     feeInBigInt,
 			AccountAddress: address,
 			ChainId:        core.ChainId,
 			GasMultiplier:  config.GasMultiplier,
@@ -61,22 +53,18 @@ func init() {
 
 	var (
 		Name              string
-		Fee               string
 		Account           string
 		JobIds            []string
 		AggregationMethod uint32
 	)
 
 	createCollectionCmd.Flags().StringVarP(&Name, "name", "n", "", "name of the collection")
-	createCollectionCmd.Flags().StringVarP(&Fee, "fee", "f", "0", "fee")
 	createCollectionCmd.Flags().StringVarP(&Account, "address", "", "", "address of the job creator")
 	createCollectionCmd.Flags().StringSliceVarP(&JobIds, "jobIds", "", []string{}, "job ids for the  collection")
 	createCollectionCmd.Flags().Uint32VarP(&AggregationMethod, "aggregation", "", 1, "aggregation method to be used")
 
 	nameErr := createCollectionCmd.MarkFlagRequired("name")
 	utils.CheckError("Name error: ", nameErr)
-	feeErr := createCollectionCmd.MarkFlagRequired("fee")
-	utils.CheckError("Fee error: ", feeErr)
 	addrErr := createCollectionCmd.MarkFlagRequired("address")
 	utils.CheckError("Address Error: ", addrErr)
 	jobIdErr := createCollectionCmd.MarkFlagRequired("jobIds")

--- a/cmd/createJob.go
+++ b/cmd/createJob.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"math/big"
 	"razor/core"
 	"razor/core/types"
 	"razor/utils"
@@ -25,23 +24,15 @@ var createJobCmd = &cobra.Command{
 		password := utils.PasswordPrompt()
 
 		address, _ := cmd.Flags().GetString("address")
-		fee, _ := cmd.Flags().GetString("fee")
 		name, _ := cmd.Flags().GetString("name")
 		repeat, _ := cmd.Flags().GetBool("repeat")
 		url, _ := cmd.Flags().GetString("url")
 		selector, _ := cmd.Flags().GetString("selector")
 
 		client := utils.ConnectToClient(config.Provider)
-
-		feeInBigInt, ok := new(big.Int).SetString(fee, 10)
-		if !ok {
-			log.Fatal("SetString: error")
-		}
-
 		txnOpts := utils.GetTxnOpts(types.TransactionOptions{
 			Client:         client,
 			Password:       password,
-			EtherValue:     feeInBigInt,
 			AccountAddress: address,
 			ChainId:        core.ChainId,
 			GasMultiplier:  config.GasMultiplier,
@@ -67,7 +58,6 @@ func init() {
 		Selector string
 		Name     string
 		Repeat   bool
-		Fee      string
 		Account  string
 	)
 
@@ -75,7 +65,6 @@ func init() {
 	createJobCmd.Flags().StringVarP(&Selector, "selector", "s", "", "selector (jsonPath selector)")
 	createJobCmd.Flags().StringVarP(&Name, "name", "n", "", "name of job")
 	createJobCmd.Flags().BoolVarP(&Repeat, "repeat", "r", true, "repeat")
-	createJobCmd.Flags().StringVarP(&Fee, "fee", "f", "0", "fee")
 	createJobCmd.Flags().StringVarP(&Account, "address", "", "", "address of the job creator")
 
 	urlErr := createJobCmd.MarkFlagRequired("url")
@@ -84,8 +73,6 @@ func init() {
 	utils.CheckError("Selector error: ", selectorErr)
 	nameErr := createJobCmd.MarkFlagRequired("name")
 	utils.CheckError("Name error: ", nameErr)
-	feeErr := createJobCmd.MarkFlagRequired("fee")
-	utils.CheckError("Fee error: ", feeErr)
 	addrErr := createJobCmd.MarkFlagRequired("address")
 	utils.CheckError("Address error: ", addrErr)
 }


### PR DESCRIPTION
Previously, `createJob` and `createCollection` functions in the smart contract were payable, but since it was removed, sending ether while calling those functions was throwing gas error. This is fixed in this commit.
    
Closes #71 

Signed-off-by: Ashish Mishra <ashish10677@gmail.com>
