### PR TITLE
Gas limit patch

### DIFF
--- a/cmd/dispute.go
+++ b/cmd/dispute.go
@@ -57,22 +57,30 @@ func Dispute(client *ethclient.Client, config types.Configurations, account type
 
 	log.Debugf("Epoch: %d, Sorted Votes: %s", epoch, sortedVotes)
 	txnOpts := utils.GetTxnOpts(types.TransactionOptions{
-		Client:         client,
-		Password:       account.Password,
-		AccountAddress: account.Address,
-		ChainId:        core.ChainId,
-		Config:         config,
+		Client:          client,
+		Password:        account.Password,
+		AccountAddress:  account.Address,
+		ChainId:         core.ChainId,
+		Config:          config,
+		ContractAddress: core.BlockManagerAddress,
+		ABI:             bindings.BlockManagerMetaData.ABI,
+		MethodName:      "giveSorted",
+		Parameters:      []interface{}{epoch, uint8(assetId), utils.ConvertBigIntArrayToUint32Array(sortedVotes)},
 	})
 
 	GiveSorted(client, blockManager, txnOpts, epoch, uint8(assetId), utils.ConvertBigIntArrayToUint32Array(sortedVotes))
 
 	log.Info("Finalizing dispute...")
 	finalizeDisputeTxnOpts := utils.GetTxnOpts(types.TransactionOptions{
-		Client:         client,
-		Password:       account.Password,
-		AccountAddress: account.Address,
-		ChainId:        core.ChainId,
-		Config:         config,
+		Client:          client,
+		Password:        account.Password,
+		AccountAddress:  account.Address,
+		ChainId:         core.ChainId,
+		Config:          config,
+		ContractAddress: core.BlockManagerAddress,
+		ABI:             bindings.BlockManagerMetaData.ABI,
+		MethodName:      "finalizeDispute",
+		Parameters:      []interface{}{epoch, blockId},
 	})
 	finalizeTxn, err := blockManager.FinalizeDispute(finalizeDisputeTxnOpts, epoch, blockId)
 	if err != nil {

--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"razor/core"
 	"razor/core/types"
+	"razor/pkg/bindings"
 	"razor/utils"
 
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -94,11 +95,15 @@ func Propose(client *ethclient.Client, account types.Account, config types.Confi
 	log.Debugf("Medians: %d", medians)
 
 	txnOpts := utils.GetTxnOpts(types.TransactionOptions{
-		Client:         client,
-		Password:       account.Password,
-		AccountAddress: account.Address,
-		ChainId:        core.ChainId,
-		Config:         config,
+		Client:          client,
+		Password:        account.Password,
+		AccountAddress:  account.Address,
+		ChainId:         core.ChainId,
+		Config:          config,
+		ContractAddress: core.BlockManagerAddress,
+		ABI:             bindings.BlockManagerMetaData.ABI,
+		MethodName:      "propose",
+		Parameters:      []interface{}{epoch, medians, big.NewInt(int64(iteration)), biggestInfluenceId},
 	})
 	blockManager := utils.GetBlockManager(client)
 

--- a/cmd/reveal.go
+++ b/cmd/reveal.go
@@ -51,14 +51,6 @@ func Reveal(client *ethclient.Client, committedData []*big.Int, secret []byte, a
 		return
 	}
 
-	txnOpts := utils.GetTxnOpts(types.TransactionOptions{
-		Client:         client,
-		Password:       account.Password,
-		AccountAddress: account.Address,
-		ChainId:        core.ChainId,
-		Config:         config,
-	})
-
 	voteManager := utils.GetVoteManager(client)
 
 	root := [32]byte{}
@@ -75,6 +67,17 @@ func Reveal(client *ethclient.Client, committedData []*big.Int, secret []byte, a
 		commitAccount,
 	)
 	log.Info("Revealing votes...")
+	txnOpts := utils.GetTxnOpts(types.TransactionOptions{
+		Client:          client,
+		Password:        account.Password,
+		AccountAddress:  account.Address,
+		ChainId:         core.ChainId,
+		Config:          config,
+		ContractAddress: core.VoteManagerAddress,
+		ABI:             bindings.VoteManagerMetaData.ABI,
+		MethodName:      "reveal",
+		Parameters:      []interface{}{epoch, committedData, secretBytes32},
+	})
 	txn, err := voteManager.Reveal(txnOpts, epoch, committedData, secretBytes32)
 	if err != nil {
 		log.Error(err)

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -205,11 +205,14 @@ func handleBlock(client *ethclient.Client, account types.Account, blockNumber *b
 	case 4:
 		if lastVerification == epoch && blockConfirmed < epoch {
 			ClaimBlockReward(types.TransactionOptions{
-				Client:         client,
-				Password:       account.Password,
-				AccountAddress: account.Address,
-				ChainId:        core.ChainId,
-				Config:         config,
+				Client:          client,
+				Password:        account.Password,
+				AccountAddress:  account.Address,
+				ChainId:         core.ChainId,
+				Config:          config,
+				ContractAddress: core.BlockManagerAddress,
+				MethodName:      "claimBlockReward",
+				ABI:             jobManager.BlockManagerMetaData.ABI,
 			})
 			blockConfirmed = epoch
 		}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -6,11 +6,15 @@ import (
 )
 
 type TransactionOptions struct {
-	Client         *ethclient.Client
-	Password       string
-	EtherValue     *big.Int
-	Amount         *big.Int
-	AccountAddress string
-	ChainId        *big.Int
-	Config         Configurations
+	Client          *ethclient.Client
+	Password        string
+	EtherValue      *big.Int
+	Amount          *big.Int
+	AccountAddress  string
+	ChainId         *big.Int
+	Config          Configurations
+	ContractAddress string
+	MethodName      string
+	Parameters      []interface{}
+	ABI             string
 }

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,11 @@ go 1.15
 
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1
-	github.com/briandowns/spinner v1.16.0
 	github.com/ethereum/go-ethereum v1.10.7
-	github.com/fatih/color v1.10.0 // indirect
 	github.com/google/go-cmp v0.5.5 // indirect
-	github.com/logrusorgru/aurora/v3 v3.0.0
 	github.com/magiconair/properties v1.8.4
 	github.com/manifoldco/promptui v0.8.0
+	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/miguelmota/go-solidity-sha3 v0.1.1
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/pelletier/go-toml v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,6 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
-github.com/briandowns/spinner v1.16.0 h1:DFmp6hEaIx2QXXuqSJmtfSBSAjRmpGiKG6ip2Wm/yOs=
-github.com/briandowns/spinner v1.16.0/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
 github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
@@ -131,8 +129,6 @@ github.com/ethereum/go-ethereum v1.10.3/go.mod h1:99onQmSd1GRGOziyGldI41YQb7EESX
 github.com/ethereum/go-ethereum v1.10.7 h1:oLcBoBwjRYVsYRXAYdm1BodfLmXSvOBUB1wQi7ghnHc=
 github.com/ethereum/go-ethereum v1.10.7/go.mod h1:cZVr8i0xeKOaPdPR+XFxrFyt9dtkOHoK2CjOoZREXaE=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
-github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 h1:FtmdgXiUlNeRsoNMFlKLDt+S+6hbjVMEW6RGQ7aUf7c=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
@@ -300,8 +296,6 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/logrusorgru/aurora/v3 v3.0.0 h1:R6zcoZZbvVcGMvDCKo45A9U/lzYyzl5NfYIvznmDfE4=
-github.com/logrusorgru/aurora/v3 v3.0.0/go.mod h1:vsR12bk5grlLvLXAYrBsb5Oc/N+LxAlxggSjiwMnCUc=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a h1:weJVJJRzAJBFRlAiJQROKQs8oC9vOxvm4rZmBBk0ONw=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -311,7 +305,6 @@ github.com/manifoldco/promptui v0.8.0 h1:R95mMF+McvXZQ7j1g8ucVZE1gLP3Sv6j9vlF9ky
 github.com/manifoldco/promptui v0.8.0/go.mod h1:n4zTdgP0vr0S3w7/O/g98U+e0gwLScEXGwov2nIKuGQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.0/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
-github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
@@ -319,7 +312,6 @@ github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d/go.mod h1:31jz6HN
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5-0.20180830101745-3fb116b82035/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -572,7 +564,6 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/utils/common.go
+++ b/utils/common.go
@@ -75,14 +75,7 @@ func WaitTillNextNSecs(waitTime int32) {
 	if waitTime <= 0 {
 		waitTime = 1
 	}
-	//s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
-	//s.Start()
-	//if err := s.Color("bgBlack", "bold", "fgYellow"); err != nil {
-	//	log.Error("Error in setting color for spinner")
-	//}
-	//s.Prefix = "Waiting for the next " + fmt.Sprint(waitTime) + " second(s) "
 	time.Sleep(time.Duration(waitTime) * time.Second)
-	//s.Stop()
 }
 
 func GetMerkleTree(data []*big.Int) (*merkletree.MerkleTree, error) {

--- a/utils/options.go
+++ b/utils/options.go
@@ -51,7 +51,7 @@ func GetTxnOpts(transactionData types.TransactionOptions) *bind.TransactOpts {
 		log.Error("Error in getting gas limit: ", err)
 	}
 	log.Debug("Estimated Gas: ", gasLimit)
-	txnOpts.GasLimit = (gasLimit*3)/20 + gasLimit
+	txnOpts.GasLimit = (gasLimit*7)/20 + gasLimit
 	log.Debug("Gas Limit after increment: ", txnOpts.GasLimit)
 
 	return txnOpts

--- a/utils/options.go
+++ b/utils/options.go
@@ -3,9 +3,12 @@ package utils
 import (
 	"context"
 	"errors"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"razor/accounts"
 	"razor/core/types"
 	"razor/path"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/ethclient"
 
@@ -43,6 +46,14 @@ func GetTxnOpts(transactionData types.TransactionOptions) *bind.TransactOpts {
 	txnOpts.GasPrice = gasPrice
 	txnOpts.Value = transactionData.EtherValue
 
+	gasLimit, err := getGasLimit(transactionData, txnOpts)
+	if err != nil {
+		log.Error("Error in getting gas limit: ", err)
+	}
+	log.Debug("Estimated Gas: ", gasLimit)
+	txnOpts.GasLimit = (gasLimit*3)/20 + gasLimit
+	log.Debug("Gas Limit after increment: ", txnOpts.GasLimit)
+
 	return txnOpts
 }
 
@@ -59,4 +70,29 @@ func getGasPrice(client *ethclient.Client, config types.Configurations) *big.Int
 	}
 	gasPrice := MultiplyFloatAndBigInt(gas, float64(config.GasMultiplier))
 	return gasPrice
+}
+
+func getGasLimit(transactionData types.TransactionOptions, txnOpts *bind.TransactOpts) (uint64, error) {
+	if transactionData.MethodName == "" {
+		return 0, nil
+	}
+	parsed, err := abi.JSON(strings.NewReader(transactionData.ABI))
+	if err != nil {
+		log.Error("Error in parsing ABI: ", err)
+		return 0, err
+	}
+	inputData, err := parsed.Pack(transactionData.MethodName, transactionData.Parameters...)
+	if err != nil {
+		log.Error("Error in calculating inputData: ", err)
+		return 0, err
+	}
+	contractAddress := common.HexToAddress(transactionData.ContractAddress)
+	msg := ethereum.CallMsg{
+		From:     common.HexToAddress(transactionData.AccountAddress),
+		To:       &contractAddress,
+		GasPrice: txnOpts.GasPrice,
+		Value:    txnOpts.Value,
+		Data:     inputData,
+	}
+	return transactionData.Client.EstimateGas(context.Background(), msg)
 }


### PR DESCRIPTION
# Description

The propose function throws an error `outOfGas` sometimes, due to the fact that `estimateGas` in razor-go doesn't always give an accurate value of gasLimit. To avoid this issue, an additional limit of 20% is added to the gas.

Fixes #236 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Voting is done with new gas limit and the new gas limits were verified to be greater than what `estimateGas` returns.

**Test Configuration**:
* Contracts version: v0.1.6
* Hardware: Macbook M1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules