### PR TITLE
Maintain list of assetIds for which GiveSorted has been called.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - run:
           name: Install go-ethereum and abigen
           command: |
-            go get -u github.com/ethereum/go-ethereum@v1.10.6
+            go get -u github.com/ethereum/go-ethereum@v1.10.7
             go install github.com/ethereum/go-ethereum/cmd/abigen
       - node/install:
           install-yarn: false

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"razor/core"
 	"razor/core/types"
+	"razor/pkg/bindings"
 	"razor/utils"
 
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -35,17 +36,22 @@ func Commit(client *ethclient.Client, data []*big.Int, secret []byte, account ty
 
 	commitment := solsha3.SoliditySHA3([]string{"uint32", "uint256[]", "bytes32"}, []interface{}{epoch, data, "0x" + hex.EncodeToString(secret)})
 	voteManager := utils.GetVoteManager(client)
-	txnOpts := utils.GetTxnOpts(types.TransactionOptions{
-		Client:         client,
-		Password:       account.Password,
-		AccountAddress: account.Address,
-		ChainId:        core.ChainId,
-		Config:         config,
-	})
 	commitmentToSend := [32]byte{}
 	copy(commitmentToSend[:], commitment)
 
 	log.Debugf("Committing: epoch: %d, commitment: %s, secret: %s, account: %s", epoch, "0x"+hex.EncodeToString(commitment), "0x"+hex.EncodeToString(secret), account.Address)
+
+	txnOpts := utils.GetTxnOpts(types.TransactionOptions{
+		Client:          client,
+		Password:        account.Password,
+		AccountAddress:  account.Address,
+		ChainId:         core.ChainId,
+		Config:          config,
+		ContractAddress: core.VoteManagerAddress,
+		ABI:             bindings.VoteManagerABI,
+		MethodName:      "commit",
+		Parameters:      []interface{}{epoch, commitmentToSend},
+	})
 
 	log.Info("Commitment sent...")
 	txn, err := voteManager.Commit(txnOpts, epoch, commitmentToSend)

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -87,7 +87,7 @@ func TestCreate(t *testing.T) {
 				}
 			} else {
 				if err.Error() != tt.wantErr.Error() {
-					t.Errorf("Error for approve function, got = %v, want %v", got, tt.wantErr)
+					t.Errorf("Error for Create function, got = %v, want %v", got, tt.wantErr)
 				}
 			}
 		})

--- a/cmd/dispute.go
+++ b/cmd/dispute.go
@@ -60,11 +60,15 @@ func Dispute(client *ethclient.Client, config types.Configurations, account type
 
 	log.Debugf("Epoch: %d, Sorted Votes: %s", epoch, sortedVotes)
 	txnOpts := utils.GetTxnOpts(types.TransactionOptions{
-		Client:         client,
-		Password:       account.Password,
-		AccountAddress: account.Address,
-		ChainId:        core.ChainId,
-		Config:         config,
+		Client:          client,
+		Password:        account.Password,
+		AccountAddress:  account.Address,
+		ChainId:         core.ChainId,
+		Config:          config,
+		ContractAddress: core.BlockManagerAddress,
+		ABI:             bindings.BlockManagerABI,
+		MethodName:      "giveSorted",
+		Parameters:      []interface{}{epoch, uint8(assetId), utils.ConvertBigIntArrayToUint32Array(sortedVotes)},
 	})
 
 	if !utils.Contains(giveSortedAssetIds, assetId) {
@@ -73,11 +77,15 @@ func Dispute(client *ethclient.Client, config types.Configurations, account type
 
 	log.Info("Finalizing dispute...")
 	finalizeDisputeTxnOpts := utils.GetTxnOpts(types.TransactionOptions{
-		Client:         client,
-		Password:       account.Password,
-		AccountAddress: account.Address,
-		ChainId:        core.ChainId,
-		Config:         config,
+		Client:          client,
+		Password:        account.Password,
+		AccountAddress:  account.Address,
+		ChainId:         core.ChainId,
+		Config:          config,
+		ContractAddress: core.BlockManagerAddress,
+		ABI:             bindings.BlockManagerABI,
+		MethodName:      "finalizeDispute",
+		Parameters:      []interface{}{epoch, blockId},
 	})
 	finalizeTxn, err := blockManager.FinalizeDispute(finalizeDisputeTxnOpts, epoch, blockId)
 	if err != nil {

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -48,6 +48,10 @@ type accountInterface interface {
 	CreateAccount(path string, password string) accounts.Account
 }
 
+type keystoreInterface interface {
+	Accounts(string) []accounts.Account
+}
+
 type flagSetInterface interface {
 	GetStringFrom(*pflag.FlagSet) (string, error)
 	GetStringTo(*pflag.FlagSet) (string, error)

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -41,6 +41,7 @@ type assetManagerInterface interface {
 
 type stakeManagerInterface interface {
 	Stake(*ethclient.Client, *bind.TransactOpts, uint32, *big.Int) (*Types.Transaction, error)
+	ResetLock(*ethclient.Client, *bind.TransactOpts, uint32) (*Types.Transaction, error)
 	Delegate(*ethclient.Client, *bind.TransactOpts, uint32, uint32, *big.Int) (*Types.Transaction, error)
 }
 
@@ -56,6 +57,7 @@ type flagSetInterface interface {
 	GetStringFrom(*pflag.FlagSet) (string, error)
 	GetStringTo(*pflag.FlagSet) (string, error)
 	GetStringAddress(*pflag.FlagSet) (string, error)
+	GetUint32StakerId(*pflag.FlagSet) (uint32, error)
 	GetStringName(*pflag.FlagSet) (string, error)
 	GetStringUrl(*pflag.FlagSet) (string, error)
 	GetStringSelector(*pflag.FlagSet) (string, error)

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -15,16 +15,20 @@ type utilsInterface interface {
 	GetOptions(bool, string, string) bind.CallOpts
 	GetTxnOpts(types.TransactionOptions) *bind.TransactOpts
 	WaitForBlockCompletion(*ethclient.Client, string) int
-	WaitForCommitState(*ethclient.Client, string, string) (uint32, error)
 	AssignPassword(*pflag.FlagSet) string
-	GetDefaultPath() (string, error)
-	GetAmountInDecimal(*big.Int) *big.Float
 	ConnectToClient(string) *ethclient.Client
+	FetchBalance(*ethclient.Client, string) (*big.Int, error)
+	AssignAmountInWei(*pflag.FlagSet) *big.Int
+	CheckAmountAndBalance(*big.Int, *big.Int) *big.Int
+	GetAmountInDecimal(*big.Int) *big.Float
+	WaitForCommitState(*ethclient.Client, string, string) (uint32, error)
+	GetDefaultPath() (string, error)
 }
 
 type tokenManagerInterface interface {
 	Allowance(*ethclient.Client, *bind.CallOpts, common.Address, common.Address) (*big.Int, error)
 	Approve(*ethclient.Client, *bind.TransactOpts, common.Address, *big.Int) (*Types.Transaction, error)
+	Transfer(*ethclient.Client, *bind.TransactOpts, common.Address, *big.Int) (*Types.Transaction, error)
 }
 
 type transactionInterface interface {
@@ -45,6 +49,8 @@ type accountInterface interface {
 }
 
 type flagSetInterface interface {
+	GetStringFrom(*pflag.FlagSet) (string, error)
+	GetStringTo(*pflag.FlagSet) (string, error)
 	GetStringAddress(*pflag.FlagSet) (string, error)
 	GetStringName(*pflag.FlagSet) (string, error)
 	GetStringUrl(*pflag.FlagSet) (string, error)

--- a/cmd/listAccounts.go
+++ b/cmd/listAccounts.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
-	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/spf13/cobra"
-	"razor/path"
 	"razor/utils"
 )
+
+var keystoreUtils keystoreInterface
 
 var listAccountsCmd = &cobra.Command{
 	Use:   "listAccounts",
@@ -14,17 +15,27 @@ var listAccountsCmd = &cobra.Command{
 Example:
   ./razor listAccounts`,
 	Run: func(cmd *cobra.Command, args []string) {
-		path, err := path.GetDefaultPath()
-		utils.CheckError("Error in fetching .razor directory", err)
-		ks := keystore.NewKeyStore(path, keystore.StandardScryptN, keystore.StandardScryptP)
-		allAccounts := ks.Accounts()
+		allAccounts, err := listAccounts(razorUtils, keystoreUtils)
+		utils.CheckError("ListAccounts error: ", err)
 		log.Info("The available accounts are: ")
 		for _, account := range allAccounts {
-			log.Infof("%s\n", account.Address.String())
+			log.Infof("%s", account.Address.String())
 		}
 	},
 }
 
+func listAccounts(razorUtils utilsInterface, keystoreUtils keystoreInterface) ([]accounts.Account, error) {
+	path, err := razorUtils.GetDefaultPath()
+	if err != nil {
+		log.Error("Error in fetching .razor directory")
+		return nil, err
+	}
+
+	return keystoreUtils.Accounts(path), nil
+}
+
 func init() {
+	razorUtils = Utils{}
+	keystoreUtils = KeystoreUtils{}
 	rootCmd.AddCommand(listAccountsCmd)
 }

--- a/cmd/listAccounts_test.go
+++ b/cmd/listAccounts_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"errors"
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"reflect"
+	"testing"
+)
+
+func Test_listAccounts(t *testing.T) {
+
+	razorUtils := UtilsMock{}
+	keystoreUtils := KeystoreMock{}
+
+	accountsList := []accounts.Account{
+		{Address: common.HexToAddress("0x000000000000000000000000000000000000dea1"),
+			URL: accounts.URL{Scheme: "TestKeyScheme", Path: "test/key/path"},
+		},
+		{Address: common.HexToAddress("0x000000000000000000000000000000000000dea2"),
+			URL: accounts.URL{Scheme: "TestKeyScheme", Path: "test/key/path"},
+		},
+	}
+
+	type args struct {
+		path     string
+		pathErr  error
+		accounts []accounts.Account
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []accounts.Account
+		wantErr error
+	}{
+		{
+			name: "When listAccounts executes successfully",
+			args: args{
+				path:     "test/key/path",
+				pathErr:  nil,
+				accounts: accountsList,
+			},
+			want:    accountsList,
+			wantErr: nil,
+		},
+		{
+			name: "When listAccounts fails due to path error",
+			args: args{
+				path:     "test/key/",
+				pathErr:  errors.New("path error"),
+				accounts: accountsList,
+			},
+			want:    nil,
+			wantErr: errors.New("path error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			GetDefaultPathMock = func() (string, error) {
+				return tt.args.path, tt.args.pathErr
+			}
+
+			AccountsMock = func(string) []accounts.Account {
+				return tt.args.accounts
+			}
+
+			got, err := listAccounts(razorUtils, keystoreUtils)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("List of accounts , got = %v, want %v", got, tt.want)
+			}
+
+			if err == nil || tt.wantErr == nil {
+				if err != tt.wantErr {
+					t.Errorf("Error for listAccounts function, got = %v, want %v", got, tt.wantErr)
+				}
+			} else {
+				if err.Error() != tt.wantErr.Error() {
+					t.Errorf("Error for listAccounts function, got = %v, want %v", got, tt.wantErr)
+				}
+			}
+
+		})
+	}
+}

--- a/cmd/mock.go
+++ b/cmd/mock.go
@@ -33,9 +33,15 @@ var WaitForBlockCompletionMock func(*ethclient.Client, string) int
 
 var WaitForCommitStateMock func(*ethclient.Client, string, string) (uint32, error)
 
+var GetDefaultPathMock func() (string, error)
+
 var AssignPasswordMock func(*pflag.FlagSet) string
 
-var GetDefaultPathMock func() (string, error)
+var FetchBalanceMock func(*ethclient.Client, string) (*big.Int, error)
+
+var AssignAmountInWeiMock func(flagSet *pflag.FlagSet) *big.Int
+
+var CheckAmountAndBalanceMock func(amountInWei *big.Int, balance *big.Int) *big.Int
 
 var GetAmountInDecimalMock func(amountInWei *big.Int) *big.Float
 
@@ -45,6 +51,8 @@ var AllowanceMock func(*ethclient.Client, *bind.CallOpts, common.Address, common
 
 var ApproveMock func(*ethclient.Client, *bind.TransactOpts, common.Address, *big.Int) (*Types.Transaction, error)
 
+var TransferMock func(*ethclient.Client, *bind.TransactOpts, common.Address, *big.Int) (*Types.Transaction, error)
+
 var HashMock func(*Types.Transaction) common.Hash
 
 var StakeMock func(*ethclient.Client, *bind.TransactOpts, uint32, *big.Int) (*Types.Transaction, error)
@@ -52,6 +60,10 @@ var StakeMock func(*ethclient.Client, *bind.TransactOpts, uint32, *big.Int) (*Ty
 var DelegateMock func(*ethclient.Client, *bind.TransactOpts, uint32, uint32, *big.Int) (*Types.Transaction, error)
 
 var CreateAccountMock func(string, string) accounts.Account
+
+var GetStringFromMock func(*pflag.FlagSet) (string, error)
+
+var GetStringToMock func(*pflag.FlagSet) (string, error)
 
 var CreateJobMock func(*bind.TransactOpts, int8, string, string, string) (*Types.Transaction, error)
 
@@ -85,6 +97,18 @@ func (u UtilsMock) AssignPassword(flagSet *pflag.FlagSet) string {
 	return AssignPasswordMock(flagSet)
 }
 
+func (u UtilsMock) FetchBalance(client *ethclient.Client, accountAddress string) (*big.Int, error) {
+	return FetchBalanceMock(client, accountAddress)
+}
+
+func (u UtilsMock) AssignAmountInWei(flagSet *pflag.FlagSet) *big.Int {
+	return AssignAmountInWeiMock(flagSet)
+}
+
+func (u UtilsMock) CheckAmountAndBalance(amountInWei *big.Int, balance *big.Int) *big.Int {
+	return CheckAmountAndBalanceMock(amountInWei, balance)
+}
+
 func (u UtilsMock) GetDefaultPath() (string, error) {
 	return GetDefaultPathMock()
 }
@@ -105,6 +129,10 @@ func (tokenManagerMock TokenManagerMock) Approve(client *ethclient.Client, opts 
 	return ApproveMock(client, opts, spender, amount)
 }
 
+func (tokenManagerMock TokenManagerMock) Transfer(client *ethclient.Client, opts *bind.TransactOpts, recipient common.Address, amount *big.Int) (*Types.Transaction, error) {
+	return TransferMock(client, opts, recipient, amount)
+}
+
 func (transactionMock TransactionMock) Hash(txn *Types.Transaction) common.Hash {
 	return HashMock(txn)
 }
@@ -123,6 +151,14 @@ func (stakeManagerMock StakeManagerMock) Delegate(client *ethclient.Client, opts
 
 func (account AccountMock) CreateAccount(path string, password string) accounts.Account {
 	return CreateAccountMock(path, password)
+}
+
+func (flagSetMock FlagSetMock) GetStringFrom(flagSet *pflag.FlagSet) (string, error) {
+	return GetStringFromMock(flagSet)
+}
+
+func (flagSetMock FlagSetMock) GetStringTo(flagSet *pflag.FlagSet) (string, error) {
+	return GetStringToMock(flagSet)
 }
 
 func (flagSetMock FlagSetMock) GetStringName(flagSet *pflag.FlagSet) (string, error) {

--- a/cmd/mock.go
+++ b/cmd/mock.go
@@ -59,6 +59,8 @@ var HashMock func(*Types.Transaction) common.Hash
 
 var StakeMock func(*ethclient.Client, *bind.TransactOpts, uint32, *big.Int) (*Types.Transaction, error)
 
+var ResetLockMock func(*ethclient.Client, *bind.TransactOpts, uint32) (*Types.Transaction, error)
+
 var DelegateMock func(*ethclient.Client, *bind.TransactOpts, uint32, uint32, *big.Int) (*Types.Transaction, error)
 
 var CreateAccountMock func(string, string) accounts.Account
@@ -72,6 +74,8 @@ var GetStringToMock func(*pflag.FlagSet) (string, error)
 var CreateJobMock func(*bind.TransactOpts, int8, string, string, string) (*Types.Transaction, error)
 
 var GetStringAddressMock func(*pflag.FlagSet) (string, error)
+
+var GetUint32StakerIdMock func(*pflag.FlagSet) (uint32, error)
 
 var GetStringNameMock func(*pflag.FlagSet) (string, error)
 
@@ -149,6 +153,10 @@ func (stakeManagerMock StakeManagerMock) Stake(client *ethclient.Client, opts *b
 	return StakeMock(client, opts, epoch, amount)
 }
 
+func (stakeManagerMock StakeManagerMock) ResetLock(client *ethclient.Client, opts *bind.TransactOpts, stakerId uint32) (*Types.Transaction, error) {
+	return ResetLockMock(client, opts, stakerId)
+}
+
 func (stakeManagerMock StakeManagerMock) Delegate(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, stakerId uint32, amount *big.Int) (*Types.Transaction, error) {
 	return DelegateMock(client, opts, epoch, stakerId, amount)
 }
@@ -171,6 +179,10 @@ func (flagSetMock FlagSetMock) GetStringTo(flagSet *pflag.FlagSet) (string, erro
 
 func (flagSetMock FlagSetMock) GetStringName(flagSet *pflag.FlagSet) (string, error) {
 	return GetStringNameMock(flagSet)
+}
+
+func (flagSetMock FlagSetMock) GetUint32StakerId(flagset *pflag.FlagSet) (uint32, error) {
+	return GetUint32StakerIdMock(flagset)
 }
 
 func (flagSetMock FlagSetMock) GetStringAddress(flagSet *pflag.FlagSet) (string, error) {

--- a/cmd/mock.go
+++ b/cmd/mock.go
@@ -23,6 +23,8 @@ type StakeManagerMock struct{}
 
 type AccountMock struct{}
 
+type KeystoreMock struct{}
+
 type FlagSetMock struct{}
 
 var GetOptionsMock func(bool, string, string) bind.CallOpts
@@ -60,6 +62,8 @@ var StakeMock func(*ethclient.Client, *bind.TransactOpts, uint32, *big.Int) (*Ty
 var DelegateMock func(*ethclient.Client, *bind.TransactOpts, uint32, uint32, *big.Int) (*Types.Transaction, error)
 
 var CreateAccountMock func(string, string) accounts.Account
+
+var AccountsMock func(string) []accounts.Account
 
 var GetStringFromMock func(*pflag.FlagSet) (string, error)
 
@@ -151,6 +155,10 @@ func (stakeManagerMock StakeManagerMock) Delegate(client *ethclient.Client, opts
 
 func (account AccountMock) CreateAccount(path string, password string) accounts.Account {
 	return CreateAccountMock(path, password)
+}
+
+func (ks KeystoreMock) Accounts(path string) []accounts.Account {
+	return AccountsMock(path)
 }
 
 func (flagSetMock FlagSetMock) GetStringFrom(flagSet *pflag.FlagSet) (string, error) {

--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"razor/core"
 	"razor/core/types"
+	"razor/pkg/bindings"
 	"razor/utils"
 
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -94,11 +95,15 @@ func Propose(client *ethclient.Client, account types.Account, config types.Confi
 	log.Debugf("Medians: %d", medians)
 
 	txnOpts := utils.GetTxnOpts(types.TransactionOptions{
-		Client:         client,
-		Password:       account.Password,
-		AccountAddress: account.Address,
-		ChainId:        core.ChainId,
-		Config:         config,
+		Client:          client,
+		Password:        account.Password,
+		AccountAddress:  account.Address,
+		ChainId:         core.ChainId,
+		Config:          config,
+		ContractAddress: core.BlockManagerAddress,
+		ABI:             bindings.BlockManagerABI,
+		MethodName:      "propose",
+		Parameters:      []interface{}{epoch, medians, big.NewInt(int64(iteration)), biggestInfluenceId},
 	})
 	blockManager := utils.GetBlockManager(client)
 

--- a/cmd/resetLock_test.go
+++ b/cmd/resetLock_test.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	Types "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/spf13/pflag"
+	"math/big"
+	"razor/core"
+	"razor/core/types"
+	"testing"
+)
+
+func Test_resetLock(t *testing.T) {
+
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
+
+	var flagSet *pflag.FlagSet
+	var config types.Configurations
+	var client *ethclient.Client
+
+	razorUtils := UtilsMock{}
+	transactionUtils := TransactionMock{}
+	stakeManagerUtils := StakeManagerMock{}
+	flagSetUtils := FlagSetMock{}
+
+	type args struct {
+		password     string
+		address      string
+		addressErr   error
+		stakerId     uint32
+		stakerIdErr  error
+		txnOpts      *bind.TransactOpts
+		resetLockTxn *Types.Transaction
+		resetLockErr error
+		hash         common.Hash
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    common.Hash
+		wantErr error
+	}{
+		{
+			name: "Test 1: When resetLock function executes successfully",
+			args: args{
+				password:     "test",
+				address:      "0x000000000000000000000000000000000000dea1",
+				addressErr:   nil,
+				stakerId:     1,
+				stakerIdErr:  nil,
+				txnOpts:      txnOpts,
+				resetLockTxn: &Types.Transaction{},
+				resetLockErr: nil,
+				hash:         common.BigToHash(big.NewInt(1)),
+			},
+			want:    common.BigToHash(big.NewInt(1)),
+			wantErr: nil,
+		},
+		{
+			name: "Test 2: When there is an error in getting address from flags",
+			args: args{
+				password:     "test",
+				address:      "",
+				addressErr:   errors.New("address error"),
+				stakerId:     1,
+				stakerIdErr:  nil,
+				txnOpts:      txnOpts,
+				resetLockTxn: &Types.Transaction{},
+				resetLockErr: nil,
+				hash:         common.BigToHash(big.NewInt(1)),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("address error"),
+		},
+		{
+			name: "Test 3: When there is an error in getting stakerId from flags",
+			args: args{
+				password:     "test",
+				address:      "0x000000000000000000000000000000000000dea1",
+				addressErr:   nil,
+				stakerIdErr:  errors.New("stakerId error"),
+				txnOpts:      txnOpts,
+				resetLockTxn: &Types.Transaction{},
+				resetLockErr: nil,
+				hash:         common.BigToHash(big.NewInt(1)),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("stakerId error"),
+		},
+		{
+			name: "Test 4: When ResetLock transaction fails",
+			args: args{
+				password:     "test",
+				address:      "0x000000000000000000000000000000000000dea1",
+				addressErr:   nil,
+				stakerId:     1,
+				stakerIdErr:  nil,
+				txnOpts:      txnOpts,
+				resetLockTxn: &Types.Transaction{},
+				resetLockErr: errors.New("resetLock error"),
+				hash:         common.BigToHash(big.NewInt(1)),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("resetLock error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			AssignPasswordMock = func(*pflag.FlagSet) string {
+				return tt.args.password
+			}
+
+			GetStringAddressMock = func(*pflag.FlagSet) (string, error) {
+				return tt.args.address, tt.args.addressErr
+			}
+
+			GetUint32StakerIdMock = func(*pflag.FlagSet) (uint32, error) {
+				return tt.args.stakerId, tt.args.stakerIdErr
+			}
+
+			ConnectToClientMock = func(string) *ethclient.Client {
+				return client
+			}
+
+			GetTxnOptsMock = func(types.TransactionOptions) *bind.TransactOpts {
+				return txnOpts
+			}
+
+			ResetLockMock = func(*ethclient.Client, *bind.TransactOpts, uint32) (*Types.Transaction, error) {
+				return tt.args.resetLockTxn, tt.args.resetLockErr
+			}
+
+			HashMock = func(*Types.Transaction) common.Hash {
+				return tt.args.hash
+			}
+
+			got, err := resetLock(flagSet, config, razorUtils, stakeManagerUtils, transactionUtils, flagSetUtils)
+			if got != tt.want {
+				t.Errorf("Txn hash for resetLock function, got = %v, want %v", got, tt.want)
+			}
+			if err == nil || tt.wantErr == nil {
+				if err != tt.wantErr {
+					t.Errorf("Error for resetLock function, got = %v, want %v", err, tt.wantErr)
+				}
+			} else {
+				if err.Error() != tt.wantErr.Error() {
+					t.Errorf("Error for resetLock function, got = %v, want %v", err, tt.wantErr)
+				}
+			}
+
+		})
+	}
+}

--- a/cmd/reveal.go
+++ b/cmd/reveal.go
@@ -51,14 +51,6 @@ func Reveal(client *ethclient.Client, committedData []*big.Int, secret []byte, a
 		return
 	}
 
-	txnOpts := utils.GetTxnOpts(types.TransactionOptions{
-		Client:         client,
-		Password:       account.Password,
-		AccountAddress: account.Address,
-		ChainId:        core.ChainId,
-		Config:         config,
-	})
-
 	voteManager := utils.GetVoteManager(client)
 
 	root := [32]byte{}
@@ -75,6 +67,17 @@ func Reveal(client *ethclient.Client, committedData []*big.Int, secret []byte, a
 		commitAccount,
 	)
 	log.Info("Revealing votes...")
+	txnOpts := utils.GetTxnOpts(types.TransactionOptions{
+		Client:          client,
+		Password:        account.Password,
+		AccountAddress:  account.Address,
+		ChainId:         core.ChainId,
+		Config:          config,
+		ContractAddress: core.VoteManagerAddress,
+		ABI:             bindings.VoteManagerABI,
+		MethodName:      "reveal",
+		Parameters:      []interface{}{epoch, committedData, secretBytes32},
+	})
 	txn, err := voteManager.Reveal(txnOpts, epoch, committedData, secretBytes32)
 	if err != nil {
 		log.Error(err)

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -46,12 +46,24 @@ func (u Utils) AssignPassword(flagSet *pflag.FlagSet) string {
 	return utils.AssignPassword(flagSet)
 }
 
-func (u Utils) GetDefaultPath() (string, error) {
-	return path.GetDefaultPath()
+func (u Utils) FetchBalance(client *ethclient.Client, accountAddress string) (*big.Int, error) {
+	return utils.FetchBalance(client, accountAddress)
+}
+
+func (u Utils) AssignAmountInWei(flagSet *pflag.FlagSet) *big.Int {
+	return utils.AssignAmountInWei(flagSet)
+}
+
+func (u Utils) CheckAmountAndBalance(amountInWei *big.Int, balance *big.Int) *big.Int {
+	return utils.CheckAmountAndBalance(amountInWei, balance)
 }
 
 func (u Utils) GetAmountInDecimal(amountInWei *big.Int) *big.Float {
 	return utils.GetAmountInDecimal(amountInWei)
+}
+
+func (u Utils) GetDefaultPath() (string, error) {
+	return path.GetDefaultPath()
 }
 
 func (tokenManagerUtils TokenManagerUtils) Allowance(client *ethclient.Client, opts *bind.CallOpts, owner common.Address, spender common.Address) (*big.Int, error) {
@@ -62,6 +74,11 @@ func (tokenManagerUtils TokenManagerUtils) Allowance(client *ethclient.Client, o
 func (tokenManagerUtils TokenManagerUtils) Approve(client *ethclient.Client, opts *bind.TransactOpts, spender common.Address, amount *big.Int) (*Types.Transaction, error) {
 	tokenManager := utils.GetTokenManager(client)
 	return tokenManager.Approve(opts, spender, amount)
+}
+
+func (tokenManagerUtils TokenManagerUtils) Transfer(client *ethclient.Client, opts *bind.TransactOpts, recipient common.Address, amount *big.Int) (*Types.Transaction, error) {
+	tokenManager := utils.GetTokenManager(client)
+	return tokenManager.Transfer(opts, recipient, amount)
 }
 
 func (transactionUtils TransactionUtils) Hash(txn *Types.Transaction) common.Hash {
@@ -85,6 +102,14 @@ func (assetManagerUtils AssetManagerUtils) CreateJob(client *ethclient.Client, o
 
 func (account AccountUtils) CreateAccount(path string, password string) ethAccounts.Account {
 	return accounts.CreateAccount(path, password)
+}
+
+func (flagSetUtils FlagSetUtils) GetStringFrom(flagSet *pflag.FlagSet) (string, error) {
+	return flagSet.GetString("from")
+}
+
+func (flagSetUtils FlagSetUtils) GetStringTo(flagSet *pflag.FlagSet) (string, error) {
+	return flagSet.GetString("to")
 }
 
 func (flagSetUtils FlagSetUtils) GetStringAddress(flagSet *pflag.FlagSet) (string, error) {

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	ethAccounts "github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	Types "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -20,6 +21,7 @@ type TransactionUtils struct{}
 type StakeManagerUtils struct{}
 type AssetManagerUtils struct{}
 type AccountUtils struct{}
+type KeystoreUtils struct{}
 type FlagSetUtils struct{}
 
 func (u Utils) ConnectToClient(provider string) *ethclient.Client {
@@ -102,6 +104,11 @@ func (assetManagerUtils AssetManagerUtils) CreateJob(client *ethclient.Client, o
 
 func (account AccountUtils) CreateAccount(path string, password string) ethAccounts.Account {
 	return accounts.CreateAccount(path, password)
+}
+
+func (keystoreUtils KeystoreUtils) Accounts(path string) []ethAccounts.Account {
+	ks := keystore.NewKeyStore(path, keystore.StandardScryptN, keystore.StandardScryptP)
+	return ks.Accounts()
 }
 
 func (flagSetUtils FlagSetUtils) GetStringFrom(flagSet *pflag.FlagSet) (string, error) {

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -92,6 +92,11 @@ func (stakeManagerUtils StakeManagerUtils) Stake(client *ethclient.Client, txnOp
 	return stakeManager.Stake(txnOpts, epoch, amount)
 }
 
+func (stakeManagerUtils StakeManagerUtils) ResetLock(client *ethclient.Client, opts *bind.TransactOpts, stakerId uint32) (*Types.Transaction, error) {
+	stakeManager := utils.GetStakeManager(client)
+	return stakeManager.ResetLock(opts, stakerId)
+}
+
 func (stakeManagerUtils StakeManagerUtils) Delegate(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, stakerId uint32, amount *big.Int) (*Types.Transaction, error) {
 	stakeManager := utils.GetStakeManager(client)
 	return stakeManager.Delegate(opts, epoch, stakerId, amount)
@@ -121,6 +126,10 @@ func (flagSetUtils FlagSetUtils) GetStringTo(flagSet *pflag.FlagSet) (string, er
 
 func (flagSetUtils FlagSetUtils) GetStringAddress(flagSet *pflag.FlagSet) (string, error) {
 	return flagSet.GetString("address")
+}
+
+func (flagSetUtils FlagSetUtils) GetUint32StakerId(flagSet *pflag.FlagSet) (uint32, error) {
+	return flagSet.GetUint32("stakerId")
 }
 
 func (flagSetUtils FlagSetUtils) GetStringName(flagSet *pflag.FlagSet) (string, error) {

--- a/cmd/transfer_test.go
+++ b/cmd/transfer_test.go
@@ -1,0 +1,208 @@
+package cmd
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	Types "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/spf13/pflag"
+	"math/big"
+	"razor/core"
+	"razor/core/types"
+	"testing"
+)
+
+func Test_transfer(t *testing.T) {
+	var client *ethclient.Client
+	var flagSet *pflag.FlagSet
+	var config types.Configurations
+
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
+
+	razorUtils := UtilsMock{}
+	transactionUtils := TransactionMock{}
+	tokenManagerUtils := TokenManagerMock{}
+	flagSetUtils := FlagSetMock{}
+
+	type args struct {
+		from          string
+		fromErr       error
+		to            string
+		toErr         error
+		password      string
+		balance       *big.Int
+		balanceErr    error
+		amount        *big.Int
+		decimalAmount *big.Float
+		txnOpts       *bind.TransactOpts
+		transferTxn   *Types.Transaction
+		transferErr   error
+		transferHash  common.Hash
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    common.Hash
+		wantErr error
+	}{
+		{
+			name: "When transfer function executes successfully",
+			args: args{
+				password:      "test",
+				from:          "0x000000000000000000000000000000000000dea1",
+				fromErr:       nil,
+				to:            "0x000000000000000000000000000000000000dea2",
+				toErr:         nil,
+				balance:       big.NewInt(1).Mul(big.NewInt(10000), big.NewInt(1e18)),
+				balanceErr:    nil,
+				amount:        big.NewInt(1).Mul(big.NewInt(1000), big.NewInt(1e18)),
+				decimalAmount: big.NewFloat(1000),
+				txnOpts:       txnOpts,
+				transferTxn:   &Types.Transaction{},
+				transferErr:   nil,
+				transferHash:  common.BigToHash(big.NewInt(1)),
+			},
+			want:    common.BigToHash(big.NewInt(1)),
+			wantErr: nil,
+		},
+		{
+			name: "When there is an error in getting 'from' address from flags",
+			args: args{
+				password:      "test",
+				from:          "",
+				fromErr:       errors.New("address error"),
+				to:            "0x000000000000000000000000000000000000dea2",
+				toErr:         nil,
+				balance:       big.NewInt(1).Mul(big.NewInt(10000), big.NewInt(1e18)),
+				balanceErr:    nil,
+				amount:        big.NewInt(1).Mul(big.NewInt(1000), big.NewInt(1e18)),
+				decimalAmount: big.NewFloat(1000),
+				txnOpts:       txnOpts,
+				transferTxn:   &Types.Transaction{},
+				transferErr:   nil,
+				transferHash:  common.BigToHash(big.NewInt(1)),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("address error"),
+		},
+		{
+			name: "When there is an error in getting 'to' address from flags",
+			args: args{
+				password:      "test",
+				from:          "0x000000000000000000000000000000000000dea1",
+				fromErr:       nil,
+				to:            "",
+				toErr:         errors.New("address error"),
+				balance:       big.NewInt(1).Mul(big.NewInt(10000), big.NewInt(1e18)),
+				balanceErr:    nil,
+				amount:        big.NewInt(1).Mul(big.NewInt(1000), big.NewInt(1e18)),
+				decimalAmount: big.NewFloat(1000),
+				txnOpts:       txnOpts,
+				transferTxn:   &Types.Transaction{},
+				transferErr:   nil,
+				transferHash:  common.BigToHash(big.NewInt(1)),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("address error"),
+		},
+		{
+			name: "When there is an error in fetching balance",
+			args: args{
+				password:      "test",
+				from:          "0x000000000000000000000000000000000000dea1",
+				fromErr:       nil,
+				to:            "0x000000000000000000000000000000000000dea2",
+				toErr:         nil,
+				balanceErr:    errors.New("balance error"),
+				amount:        big.NewInt(1).Mul(big.NewInt(1000), big.NewInt(1e18)),
+				decimalAmount: big.NewFloat(1000),
+				txnOpts:       txnOpts,
+				transferTxn:   &Types.Transaction{},
+				transferErr:   nil,
+				transferHash:  common.BigToHash(big.NewInt(1)),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("balance error"),
+		},
+		{
+			name: "When transfer transaction fails",
+			args: args{
+				password:      "test",
+				from:          "0x000000000000000000000000000000000000dea1",
+				fromErr:       nil,
+				to:            "0x000000000000000000000000000000000000dea2",
+				toErr:         nil,
+				balance:       big.NewInt(1).Mul(big.NewInt(10000), big.NewInt(1e18)),
+				balanceErr:    nil,
+				amount:        big.NewInt(1).Mul(big.NewInt(1000), big.NewInt(1e18)),
+				decimalAmount: big.NewFloat(1000),
+				txnOpts:       txnOpts,
+				transferTxn:   &Types.Transaction{},
+				transferErr:   errors.New("transfer error"),
+				transferHash:  common.BigToHash(big.NewInt(1)),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("transfer error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			AssignPasswordMock = func(set *pflag.FlagSet) string {
+				return tt.args.password
+			}
+
+			GetStringFromMock = func(*pflag.FlagSet) (string, error) {
+				return tt.args.from, tt.args.fromErr
+			}
+
+			GetStringToMock = func(*pflag.FlagSet) (string, error) {
+				return tt.args.to, tt.args.toErr
+			}
+
+			ConnectToClientMock = func(string) *ethclient.Client {
+				return client
+			}
+			FetchBalanceMock = func(*ethclient.Client, string) (*big.Int, error) {
+				return tt.args.balance, tt.args.balanceErr
+			}
+			AssignAmountInWeiMock = func(set *pflag.FlagSet) *big.Int {
+				return tt.args.amount
+			}
+			CheckAmountAndBalanceMock = func(*big.Int, *big.Int) *big.Int {
+				return tt.args.amount
+			}
+			GetTxnOptsMock = func(types.TransactionOptions) *bind.TransactOpts {
+				return tt.args.txnOpts
+			}
+			GetAmountInDecimalMock = func(*big.Int) *big.Float {
+				return tt.args.decimalAmount
+			}
+			TransferMock = func(*ethclient.Client, *bind.TransactOpts, common.Address, *big.Int) (*Types.Transaction, error) {
+				return tt.args.transferTxn, tt.args.transferErr
+			}
+			HashMock = func(*Types.Transaction) common.Hash {
+				return tt.args.transferHash
+			}
+
+			got, err := transfer(flagSet, config, razorUtils, tokenManagerUtils, transactionUtils, flagSetUtils)
+			if got != tt.want {
+				t.Errorf("Txn hash for transfer function, got = %v, want %v", got, tt.want)
+			}
+			if err == nil || tt.wantErr == nil {
+				if err != tt.wantErr {
+					t.Errorf("Error for transfer function, got = %v, want %v", got, tt.wantErr)
+				}
+			} else {
+				if err.Error() != tt.wantErr.Error() {
+					t.Errorf("Error for transfer function, got = %v, want %v", got, tt.wantErr)
+				}
+			}
+
+		})
+	}
+}

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -205,11 +205,14 @@ func handleBlock(client *ethclient.Client, account types.Account, blockNumber *b
 	case 4:
 		if lastVerification == epoch && blockConfirmed < epoch {
 			ClaimBlockReward(types.TransactionOptions{
-				Client:         client,
-				Password:       account.Password,
-				AccountAddress: account.Address,
-				ChainId:        core.ChainId,
-				Config:         config,
+				Client:          client,
+				Password:        account.Password,
+				AccountAddress:  account.Address,
+				ChainId:         core.ChainId,
+				Config:          config,
+				ContractAddress: core.BlockManagerAddress,
+				MethodName:      "claimBlockReward",
+				ABI:             jobManager.BlockManagerABI,
 			})
 			blockConfirmed = epoch
 		}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -6,11 +6,15 @@ import (
 )
 
 type TransactionOptions struct {
-	Client         *ethclient.Client
-	Password       string
-	EtherValue     *big.Int
-	Amount         *big.Int
-	AccountAddress string
-	ChainId        *big.Int
-	Config         Configurations
+	Client          *ethclient.Client
+	Password        string
+	EtherValue      *big.Int
+	Amount          *big.Int
+	AccountAddress  string
+	ChainId         *big.Int
+	Config          Configurations
+	ContractAddress string
+	MethodName      string
+	Parameters      []interface{}
+	ABI             string
 }

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,11 @@ go 1.15
 
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1
-	github.com/briandowns/spinner v1.16.0
 	github.com/ethereum/go-ethereum v1.10.7
-	github.com/fatih/color v1.10.0 // indirect
 	github.com/google/go-cmp v0.5.5 // indirect
-	github.com/logrusorgru/aurora/v3 v3.0.0
 	github.com/magiconair/properties v1.8.4
 	github.com/manifoldco/promptui v0.8.0
+	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/miguelmota/go-solidity-sha3 v0.1.1
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/pelletier/go-toml v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,6 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
-github.com/briandowns/spinner v1.16.0 h1:DFmp6hEaIx2QXXuqSJmtfSBSAjRmpGiKG6ip2Wm/yOs=
-github.com/briandowns/spinner v1.16.0/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
 github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
@@ -131,8 +129,6 @@ github.com/ethereum/go-ethereum v1.10.3/go.mod h1:99onQmSd1GRGOziyGldI41YQb7EESX
 github.com/ethereum/go-ethereum v1.10.7 h1:oLcBoBwjRYVsYRXAYdm1BodfLmXSvOBUB1wQi7ghnHc=
 github.com/ethereum/go-ethereum v1.10.7/go.mod h1:cZVr8i0xeKOaPdPR+XFxrFyt9dtkOHoK2CjOoZREXaE=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
-github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 h1:FtmdgXiUlNeRsoNMFlKLDt+S+6hbjVMEW6RGQ7aUf7c=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
@@ -300,8 +296,6 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/logrusorgru/aurora/v3 v3.0.0 h1:R6zcoZZbvVcGMvDCKo45A9U/lzYyzl5NfYIvznmDfE4=
-github.com/logrusorgru/aurora/v3 v3.0.0/go.mod h1:vsR12bk5grlLvLXAYrBsb5Oc/N+LxAlxggSjiwMnCUc=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a h1:weJVJJRzAJBFRlAiJQROKQs8oC9vOxvm4rZmBBk0ONw=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -311,7 +305,6 @@ github.com/manifoldco/promptui v0.8.0 h1:R95mMF+McvXZQ7j1g8ucVZE1gLP3Sv6j9vlF9ky
 github.com/manifoldco/promptui v0.8.0/go.mod h1:n4zTdgP0vr0S3w7/O/g98U+e0gwLScEXGwov2nIKuGQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.0/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
-github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-ieproxy v0.0.0-20190610004146-91bb50d98149/go.mod h1:31jz6HNzdxOmlERGGEc4v/dMssOfmp2p5bT/okiKFFc=
@@ -319,7 +312,6 @@ github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d/go.mod h1:31jz6HN
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5-0.20180830101745-3fb116b82035/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -572,7 +564,6 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,11 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "razor-go",
       "version": "v0.1.6",
       "license": "ISC",
       "dependencies": {
-        "@razor-network/contracts": "0.1.6"
+        "@razor-network/contracts": "0.1.62"
       }
     },
     "node_modules/@ethereumjs/block": {
@@ -276,9 +277,9 @@
       "integrity": "sha512-LD4NnkKpHHSMo5z9MvFsG4g1xxZUDqV3A3Futu3nvyfs4wPwXxqOgMaxOoa2PeyGL2VNeSlbxT54enbQzGcgJQ=="
     },
     "node_modules/@razor-network/contracts": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@razor-network/contracts/-/contracts-0.1.6.tgz",
-      "integrity": "sha512-Jv4VIBu7z2ZiFxQYxoy0HiNToThr/5bWihJs+59IZRdAhNxH6rMe9vYOqIZf+O3/SZGzE2FPn8/LdDW8et4lIw==",
+      "version": "0.1.62",
+      "resolved": "https://registry.npmjs.org/@razor-network/contracts/-/contracts-0.1.62.tgz",
+      "integrity": "sha512-rQ+QGpfjOSUEopcYgI4XxYYThhhpRlxpR+eAaPcQGUgJTSbAHjl3mI8sRILubKhAa3HJdqbBWYELhUDUV2u8xA==",
       "dependencies": {
         "@openzeppelin/contracts": "^4.2.0",
         "hardhat-abi-exporter": "^2.2.1",
@@ -809,7 +810,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1438,9 +1438,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2046,7 +2043,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -2080,9 +2076,6 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.9"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
       }
@@ -2484,7 +2477,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3175,9 +3167,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4029,9 +4018,9 @@
       "integrity": "sha512-LD4NnkKpHHSMo5z9MvFsG4g1xxZUDqV3A3Futu3nvyfs4wPwXxqOgMaxOoa2PeyGL2VNeSlbxT54enbQzGcgJQ=="
     },
     "@razor-network/contracts": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@razor-network/contracts/-/contracts-0.1.6.tgz",
-      "integrity": "sha512-Jv4VIBu7z2ZiFxQYxoy0HiNToThr/5bWihJs+59IZRdAhNxH6rMe9vYOqIZf+O3/SZGzE2FPn8/LdDW8et4lIw==",
+      "version": "0.1.62",
+      "resolved": "https://registry.npmjs.org/@razor-network/contracts/-/contracts-0.1.62.tgz",
+      "integrity": "sha512-rQ+QGpfjOSUEopcYgI4XxYYThhhpRlxpR+eAaPcQGUgJTSbAHjl3mI8sRILubKhAa3HJdqbBWYELhUDUV2u8xA==",
       "requires": {
         "@openzeppelin/contracts": "^4.2.0",
         "hardhat-abi-exporter": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/razor-network/razor-go#readme",
   "dependencies": {
-    "@razor-network/contracts": "0.1.6"
+    "@razor-network/contracts": "0.1.62"
   }
 }

--- a/utils/array.go
+++ b/utils/array.go
@@ -5,12 +5,12 @@ import (
 	"math/big"
 )
 
-func Contains(arr []*big.Int, val *big.Int) bool {
-	if val == nil || len(arr) == 0 {
+func Contains(arr []int, val int) bool {
+	if len(arr) == 0 {
 		return false
 	}
 	for _, value := range arr {
-		if value.Cmp(val) == 0 {
+		if value == val {
 			return true
 		}
 	}

--- a/utils/array_test.go
+++ b/utils/array_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestContains(t *testing.T) {
 	type args struct {
-		arr []*big.Int
-		val *big.Int
+		arr []int
+		val int
 	}
 	tests := []struct {
 		name string
@@ -18,36 +18,28 @@ func TestContains(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "Test 1",
+			name: "Test if value is not present in the array",
 			args: args{
-				arr: []*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2)},
-				val: nil,
+				arr: []int{0, 1, 2},
+				val: 4,
 			},
 			want: false,
 		},
 		{
-			name: "Test 2",
+			name: "Test if value is present in the array",
 			args: args{
-				arr: []*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2)},
-				val: big.NewInt(4),
-			},
-			want: false,
-		},
-		{
-			name: "Test 3",
-			args: args{
-				arr: []*big.Int{},
-				val: big.NewInt(4),
-			},
-			want: false,
-		},
-		{
-			name: "Test 4",
-			args: args{
-				arr: []*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2)},
-				val: big.NewInt(1),
+				arr: []int{0, 1, 2},
+				val: 2,
 			},
 			want: true,
+		},
+		{
+			name: "Test if array is empty",
+			args: args{
+				arr: []int{},
+				val: 4,
+			},
+			want: false,
 		},
 	}
 	for _, tt := range tests {

--- a/utils/common.go
+++ b/utils/common.go
@@ -75,14 +75,7 @@ func WaitTillNextNSecs(waitTime int32) {
 	if waitTime <= 0 {
 		waitTime = 1
 	}
-	//s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
-	//s.Start()
-	//if err := s.Color("bgBlack", "bold", "fgYellow"); err != nil {
-	//	log.Error("Error in setting color for spinner")
-	//}
-	//s.Prefix = "Waiting for the next " + fmt.Sprint(waitTime) + " second(s) "
 	time.Sleep(time.Duration(waitTime) * time.Second)
-	//s.Stop()
 }
 
 func GetMerkleTree(data []*big.Int) (*merkletree.MerkleTree, error) {


### PR DESCRIPTION
# Description

`GiveSorted` must be called once for a particular asset id. We now maintain a list of asset ids for which `GiveSorted` has been called, and if the current asset id is not present in that array, only then, `GiveSorted` is called.

Fixes #237 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules