### PR TITLE
Maintain list of assetIds for which giveSorted has been called already.

### DIFF
--- a/cmd/dispute.go
+++ b/cmd/dispute.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
+var giveSortedAssetIds []int
+
 func HandleDispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32) {
 	numberOfProposedBlocks, err := utils.GetNumberOfProposedBlocks(client, account.Address, epoch)
 	if err != nil {
@@ -46,6 +48,7 @@ func HandleDispute(client *ethclient.Client, config types.Configurations, accoun
 			break
 		}
 	}
+	giveSortedAssetIds = []int{}
 }
 
 func Dispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockId uint8, assetId int) error {
@@ -57,30 +60,24 @@ func Dispute(client *ethclient.Client, config types.Configurations, account type
 
 	log.Debugf("Epoch: %d, Sorted Votes: %s", epoch, sortedVotes)
 	txnOpts := utils.GetTxnOpts(types.TransactionOptions{
-		Client:          client,
-		Password:        account.Password,
-		AccountAddress:  account.Address,
-		ChainId:         core.ChainId,
-		Config:          config,
-		ContractAddress: core.BlockManagerAddress,
-		ABI:             bindings.BlockManagerABI,
-		MethodName:      "giveSorted",
-		Parameters:      []interface{}{epoch, uint8(assetId), utils.ConvertBigIntArrayToUint32Array(sortedVotes)},
+		Client:         client,
+		Password:       account.Password,
+		AccountAddress: account.Address,
+		ChainId:        core.ChainId,
+		Config:         config,
 	})
 
-	GiveSorted(client, blockManager, txnOpts, epoch, uint8(assetId), utils.ConvertBigIntArrayToUint32Array(sortedVotes))
+	if !utils.Contains(giveSortedAssetIds, assetId) {
+		GiveSorted(client, blockManager, txnOpts, epoch, uint8(assetId), utils.ConvertBigIntArrayToUint32Array(sortedVotes))
+	}
 
 	log.Info("Finalizing dispute...")
 	finalizeDisputeTxnOpts := utils.GetTxnOpts(types.TransactionOptions{
-		Client:          client,
-		Password:        account.Password,
-		AccountAddress:  account.Address,
-		ChainId:         core.ChainId,
-		Config:          config,
-		ContractAddress: core.BlockManagerAddress,
-		ABI:             bindings.BlockManagerABI,
-		MethodName:      "finalizeDispute",
-		Parameters:      []interface{}{epoch, blockId},
+		Client:         client,
+		Password:       account.Password,
+		AccountAddress: account.Address,
+		ChainId:        core.ChainId,
+		Config:         config,
 	})
 	finalizeTxn, err := blockManager.FinalizeDispute(finalizeDisputeTxnOpts, epoch, blockId)
 	if err != nil {
@@ -101,5 +98,6 @@ func GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, t
 	}
 	log.Info("Calling GiveSorted...")
 	log.Info("Txn Hash: ", txn.Hash())
+	giveSortedAssetIds = append(giveSortedAssetIds, int(assetId))
 	utils.WaitForBlockCompletion(client, txn.Hash().String())
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "razor-go",
       "version": "v0.1.6",
       "license": "ISC",
       "dependencies": {

--- a/utils/array.go
+++ b/utils/array.go
@@ -5,12 +5,12 @@ import (
 	"math/big"
 )
 
-func Contains(arr []*big.Int, val *big.Int) bool {
-	if val == nil || len(arr) == 0 {
+func Contains(arr []int, val int) bool {
+	if len(arr) == 0 {
 		return false
 	}
 	for _, value := range arr {
-		if value.Cmp(val) == 0 {
+		if value == val {
 			return true
 		}
 	}

--- a/utils/array_test.go
+++ b/utils/array_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestContains(t *testing.T) {
 	type args struct {
-		arr []*big.Int
-		val *big.Int
+		arr []int
+		val int
 	}
 	tests := []struct {
 		name string
@@ -18,36 +18,28 @@ func TestContains(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "Test 1",
+			name: "Test if value is not present in the array",
 			args: args{
-				arr: []*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2)},
-				val: nil,
+				arr: []int{0, 1, 2},
+				val: 4,
 			},
 			want: false,
 		},
 		{
-			name: "Test 2",
+			name: "Test if value is present in the array",
 			args: args{
-				arr: []*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2)},
-				val: big.NewInt(4),
-			},
-			want: false,
-		},
-		{
-			name: "Test 3",
-			args: args{
-				arr: []*big.Int{},
-				val: big.NewInt(4),
-			},
-			want: false,
-		},
-		{
-			name: "Test 4",
-			args: args{
-				arr: []*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2)},
-				val: big.NewInt(1),
+				arr: []int{0, 1, 2},
+				val: 2,
 			},
 			want: true,
+		},
+		{
+			name: "Test if array is empty",
+			args: args{
+				arr: []int{},
+				val: 4,
+			},
+			want: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

`GiveSorted` must be called once for a particular asset id. We now maintain a list of asset ids for which `GiveSorted` has been called, and if the current asset id is not present in that array, only then, `GiveSorted` is called.

Fixes #237 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules