### PR TITLE
Remove multiplication with power on collection aggregation.

### DIFF
--- a/utils/math.go
+++ b/utils/math.go
@@ -132,10 +132,10 @@ func Aggregate(client *ethclient.Client, address string, previousEpoch uint32, c
 		}
 		return big.NewInt(int64(prevCommitmentData)), nil
 	}
-	return performAggregation(dataToCommit, collection.AggregationMethod, collection.Power)
+	return performAggregation(dataToCommit, collection.AggregationMethod)
 }
 
-func performAggregation(data []*big.Int, aggregationMethod uint32, power int8) (*big.Int, error) {
+func performAggregation(data []*big.Int, aggregationMethod uint32) (*big.Int, error) {
 	if len(data) == 0 {
 		return nil, errors.New("aggregation cannot be performed for nil data")
 	}
@@ -144,11 +144,11 @@ func performAggregation(data []*big.Int, aggregationMethod uint32, power int8) (
 	case 1:
 		sortutil.BigIntSlice.Sort(data)
 		median := data[len(data)/2]
-		return MultiplyWithPower(big.NewFloat(float64(median.Int64())), power), nil
+		return big.NewInt(median.Int64()), nil
 	case 2:
 		sum := CalculateSumOfArray(data)
 		mean := sum.Div(sum, big.NewInt(int64(len(data))))
-		return MultiplyWithPower(big.NewFloat(float64(mean.Int64())), power), nil
+		return big.NewInt(mean.Int64()), nil
 	}
 	return nil, errors.New("invalid aggregation method")
 }

--- a/utils/math_test.go
+++ b/utils/math_test.go
@@ -377,7 +377,6 @@ func Test_performAggregation(t *testing.T) {
 	type args struct {
 		data              []*big.Int
 		aggregationMethod uint32
-		power             int8
 	}
 
 	tests := []struct {
@@ -391,9 +390,8 @@ func Test_performAggregation(t *testing.T) {
 			args: args{
 				data:              []*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2)},
 				aggregationMethod: 1,
-				power:             2,
 			},
-			want:    big.NewInt(100),
+			want:    big.NewInt(1),
 			wantErr: false,
 		},
 		{
@@ -401,9 +399,8 @@ func Test_performAggregation(t *testing.T) {
 			args: args{
 				data:              []*big.Int{big.NewInt(0), big.NewInt(1)},
 				aggregationMethod: 1,
-				power:             3,
 			},
-			want:    big.NewInt(1000),
+			want:    big.NewInt(1),
 			wantErr: false,
 		},
 		{
@@ -411,7 +408,6 @@ func Test_performAggregation(t *testing.T) {
 			args: args{
 				data:              []*big.Int{big.NewInt(1)},
 				aggregationMethod: 1,
-				power:             0,
 			},
 			want:    big.NewInt(1),
 			wantErr: false,
@@ -421,9 +417,8 @@ func Test_performAggregation(t *testing.T) {
 			args: args{
 				data:              []*big.Int{big.NewInt(500), big.NewInt(1000), big.NewInt(1500), big.NewInt(2000)},
 				aggregationMethod: 1,
-				power:             8,
 			},
-			want:    big.NewInt(150000000000),
+			want:    big.NewInt(1500),
 			wantErr: false,
 		},
 		{
@@ -431,7 +426,6 @@ func Test_performAggregation(t *testing.T) {
 			args: args{
 				data:              []*big.Int{},
 				aggregationMethod: 1,
-				power:             0,
 			},
 			want:    nil,
 			wantErr: true,
@@ -441,9 +435,8 @@ func Test_performAggregation(t *testing.T) {
 			args: args{
 				data:              []*big.Int{big.NewInt(0), big.NewInt(10), big.NewInt(20)},
 				aggregationMethod: 2,
-				power:             -1,
 			},
-			want:    big.NewInt(1),
+			want:    big.NewInt(10),
 			wantErr: false,
 		},
 		{
@@ -451,9 +444,8 @@ func Test_performAggregation(t *testing.T) {
 			args: args{
 				data:              []*big.Int{big.NewInt(100000)},
 				aggregationMethod: 2,
-				power:             -2,
 			},
-			want:    big.NewInt(1000),
+			want:    big.NewInt(100000),
 			wantErr: false,
 		},
 		{
@@ -461,9 +453,8 @@ func Test_performAggregation(t *testing.T) {
 			args: args{
 				data:              []*big.Int{big.NewInt(500), big.NewInt(1000), big.NewInt(1500), big.NewInt(2000)},
 				aggregationMethod: 2,
-				power:             -1,
 			},
-			want:    big.NewInt(125),
+			want:    big.NewInt(1250),
 			wantErr: false,
 		},
 		{
@@ -471,7 +462,6 @@ func Test_performAggregation(t *testing.T) {
 			args: args{
 				data:              []*big.Int{},
 				aggregationMethod: 2,
-				power:             0,
 			},
 			want:    nil,
 			wantErr: true,
@@ -481,7 +471,6 @@ func Test_performAggregation(t *testing.T) {
 			args: args{
 				data:              []*big.Int{big.NewInt(1)},
 				aggregationMethod: 3,
-				power:             2,
 			},
 			want:    nil,
 			wantErr: true,
@@ -489,7 +478,7 @@ func Test_performAggregation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := performAggregation(tt.args.data, tt.args.aggregationMethod, tt.args.power)
+			got, err := performAggregation(tt.args.data, tt.args.aggregationMethod)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetDataFromJSON() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
# Description

During aggregation, power of the collection was being used to multiply the result. But that is not required.

Fixes #265 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Test cases have been verified.

**Test Configuration**:
* Contracts version: `v0.1.6`
* Hardware: Macbook Air M1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules