### PR TITLE
Changed stakerId default value when stakerId flag is not passed

### DIFF
--- a/cmd/unstake.go
+++ b/cmd/unstake.go
@@ -24,7 +24,6 @@ Example:
 
 		password := utils.AssignPassword(cmd.Flags())
 		address, _ := cmd.Flags().GetString("address")
-		stakerId, _ := cmd.Flags().GetUint32("stakerId")
 		autoWithdraw, _ := cmd.Flags().GetBool("autoWithdraw")
 
 		client := utils.ConnectToClient(config.Provider)
@@ -32,6 +31,9 @@ Example:
 		valueInWei := utils.AssignAmountInWei(cmd.Flags())
 
 		utils.CheckEthBalanceIsZero(client, address)
+
+		stakerId, err := utils.AssignStakerId(cmd.Flags(), client, address)
+		utils.CheckError("StakerId error: ", err)
 
 		lock, err := utils.GetLock(client, address, stakerId)
 		utils.CheckError("Error in getting lock: ", err)

--- a/cmd/withdraw.go
+++ b/cmd/withdraw.go
@@ -26,12 +26,14 @@ Example:
 
 		password := utils.AssignPassword(cmd.Flags())
 		address, _ := cmd.Flags().GetString("address")
-		stakerId, _ := cmd.Flags().GetUint32("stakerId")
 
 		client := utils.ConnectToClient(config.Provider)
 		utils.CheckError("Error in fetching staker id: ", err)
 
 		utils.CheckEthBalanceIsZero(client, address)
+
+		stakerId, err := utils.AssignStakerId(cmd.Flags(), client, address)
+		utils.CheckError("StakerId error: ", err)
 
 		checkForCommitStateAndWithdraw(client, types.Account{
 			Address:  address,

--- a/utils/common.go
+++ b/utils/common.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"github.com/spf13/pflag"
 	"math"
 	"math/big"
 	"os"
@@ -141,4 +142,11 @@ func GetStateName(stateNumber int64) string {
 		stateName = "-1"
 	}
 	return stateName
+}
+
+func AssignStakerId(flagSet *pflag.FlagSet, client *ethclient.Client, address string) (uint32, error) {
+	if IsFlagPassed("stakerId") {
+		return flagSet.GetUint32("stakerId")
+	}
+	return GetStakerId(client, address)
 }


### PR DESCRIPTION
# Description
Fixed default value of `stakerId` when stakerId flag is not passed in unstake and withdraw command.

Fixes #284 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules