### PR TITLE
Reduce calculations in handle dispute.

### DIFF
--- a/cmd/dispute_test.go
+++ b/cmd/dispute_test.go
@@ -292,7 +292,7 @@ func TestHandleDispute(t *testing.T) {
 				isEqual:        true,
 				disputeErr:     nil,
 			},
-			want: nil,
+			want: errors.New("medians error"),
 		},
 		{
 			name: "Test 6: When there is an error from Dispute function",

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -65,7 +65,6 @@ type utilsInterface interface {
 	GetSortedProposedBlockIds(*ethclient.Client, string, uint32) ([]uint8, error)
 	GetUpdatedEpoch(*ethclient.Client) (uint32, error)
 }
-
 type tokenManagerInterface interface {
 	Allowance(*ethclient.Client, *bind.CallOpts, common.Address, common.Address) (*big.Int, error)
 	Approve(*ethclient.Client, *bind.TransactOpts, common.Address, *big.Int) (*Types.Transaction, error)


### PR DESCRIPTION
# Description

Local median calculation is done only once now to speed up the dispute process.

Fixes #358 

## Type of change

- [x] Optimization

# How Has This Been Tested?

- [x] Tested on local hardhat network with 5 stakers

**Test Configuration**:
* Contracts version: v0.1.76
* Hardware: Macbook M1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules