### PR TITLE
Unstake Input fix

### DIFF
--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -72,6 +72,9 @@ type utilsInterface interface {
 	GetAmountInWei(*big.Int) *big.Int
 	Sleep(time.Duration)
 	CalculateBlockTime(*ethclient.Client) int64
+	GetStakedToken(*ethclient.Client, common.Address) *bindings.StakedToken
+	ConvertSRZRToRZR(*big.Int, *big.Int, *big.Int) *big.Int
+	ConvertRZRToSRZR(*big.Int, *big.Int, *big.Int) (*big.Int, error)
 }
 
 type tokenManagerInterface interface {
@@ -108,6 +111,8 @@ type stakeManagerInterface interface {
 	StakerInfo(*ethclient.Client, *bind.CallOpts, uint32) (types.Staker, error)
 	GetMaturity(*ethclient.Client, *bind.CallOpts, uint32) (uint16, error)
 	GetBountyLock(*ethclient.Client, *bind.CallOpts, uint32) (types.BountyLock, error)
+	BalanceOf(*bindings.StakedToken, *bind.CallOpts, common.Address) (*big.Int, error)
+	GetTotalSupply(*bindings.StakedToken, *bind.CallOpts) (*big.Int, error)
 }
 
 type accountInterface interface {

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -171,6 +171,7 @@ type utilsCmdInterface interface {
 	withdrawFunds(*ethclient.Client, types.Account, types.Configurations, uint32, UtilsStruct) (common.Hash, error)
 	Create(string, UtilsStruct) (accounts.Account, error)
 	claimBounty(types.Configurations, *ethclient.Client, types.RedeemBountyInput, UtilsStruct) (common.Hash, error)
+	GetAmountInSRZRs(*ethclient.Client, string, bindings.StructsStaker, *big.Int, UtilsStruct) (*big.Int, error)
 }
 
 type cryptoInterface interface {

--- a/cmd/mock.go
+++ b/cmd/mock.go
@@ -277,6 +277,8 @@ var CreateMock func(string, UtilsStruct) (accounts.Account, error)
 
 var claimBountyMock func(types.Configurations, *ethclient.Client, types.RedeemBountyInput, UtilsStruct) (common.Hash, error)
 
+var GetAmountInSRZRsMock func(*ethclient.Client, string, bindings.StructsStaker, *big.Int, UtilsStruct) (*big.Int, error)
+
 var GetStringProviderMock func(*pflag.FlagSet) (string, error)
 
 var GetFloat32GasMultiplierMock func(set *pflag.FlagSet) (float32, error)
@@ -887,6 +889,10 @@ func (utilsCmdMock UtilsCmdMock) Create(password string, utilsStruct UtilsStruct
 
 func (utilsCmdMock UtilsCmdMock) claimBounty(config types.Configurations, client *ethclient.Client, redeemBountyInput types.RedeemBountyInput, utilsStruct UtilsStruct) (common.Hash, error) {
 	return claimBountyMock(config, client, redeemBountyInput, utilsStruct)
+}
+
+func (utilsCmdMock UtilsCmdMock) GetAmountInSRZRs(client *ethclient.Client, address string, staker bindings.StructsStaker, amount *big.Int, utilsStruct UtilsStruct) (*big.Int, error) {
+	return GetAmountInSRZRsMock(client, address, staker, amount, utilsStruct)
 }
 
 func (blockManagerMock BlockManagerMock) ClaimBlockReward(client *ethclient.Client, opts *bind.TransactOpts) (*Types.Transaction, error) {

--- a/cmd/mock.go
+++ b/cmd/mock.go
@@ -159,7 +159,13 @@ var GetAmountInWeiMock func(*big.Int) *big.Int
 
 var SleepMock func(time.Duration)
 
+var GetStakedTokenMock func(*ethclient.Client, common.Address) *bindings.StakedToken
+
 var CalculateBlockTimeMock func(*ethclient.Client) int64
+
+var ConvertSRZRToRZRMock func(*big.Int, *big.Int, *big.Int) *big.Int
+
+var ConvertRZRToSRZRMock func(*big.Int, *big.Int, *big.Int) (*big.Int, error)
 
 var AllowanceMock func(*ethclient.Client, *bind.CallOpts, common.Address, common.Address) (*big.Int, error)
 
@@ -192,6 +198,10 @@ var StakerInfoMock func(*ethclient.Client, *bind.CallOpts, uint32) (types.Staker
 var GetMaturityMock func(*ethclient.Client, *bind.CallOpts, uint32) (uint16, error)
 
 var GetBountyLockMock func(*ethclient.Client, *bind.CallOpts, uint32) (types.BountyLock, error)
+
+var BalanceOfMock func(*bindings.StakedToken, *bind.CallOpts, common.Address) (*big.Int, error)
+
+var GetTotalSupplyMock func(*bindings.StakedToken, *bind.CallOpts) (*big.Int, error)
 
 var CreateAccountMock func(string, string) accounts.Account
 
@@ -547,6 +557,18 @@ func (u UtilsMock) CalculateBlockTime(client *ethclient.Client) int64 {
 	return CalculateBlockTimeMock(client)
 }
 
+func (u UtilsMock) GetStakedToken(client *ethclient.Client, address common.Address) *bindings.StakedToken {
+	return GetStakedTokenMock(client, address)
+}
+
+func (u UtilsMock) ConvertSRZRToRZR(sAmount *big.Int, currentStake *big.Int, totalSupply *big.Int) *big.Int {
+	return ConvertSRZRToRZRMock(sAmount, currentStake, totalSupply)
+}
+
+func (u UtilsMock) ConvertRZRToSRZR(sAmount *big.Int, currentStake *big.Int, totalSupply *big.Int) (*big.Int, error) {
+	return ConvertRZRToSRZRMock(sAmount, currentStake, totalSupply)
+}
+
 func (tokenManagerMock TokenManagerMock) Allowance(client *ethclient.Client, opts *bind.CallOpts, owner common.Address, spender common.Address) (*big.Int, error) {
 	return AllowanceMock(client, opts, owner, spender)
 }
@@ -633,6 +655,14 @@ func (stakeManagerMock StakeManagerMock) GetMaturity(client *ethclient.Client, o
 
 func (stakeManagerMock StakeManagerMock) GetBountyLock(client *ethclient.Client, opts *bind.CallOpts, bountyId uint32) (types.BountyLock, error) {
 	return GetBountyLockMock(client, opts, bountyId)
+}
+
+func (stakeManagerMock StakeManagerMock) BalanceOf(stakedToken *bindings.StakedToken, callOpts *bind.CallOpts, address common.Address) (*big.Int, error) {
+	return BalanceOfMock(stakedToken, callOpts, address)
+}
+
+func (stakeManagerMock StakeManagerMock) GetTotalSupply(token *bindings.StakedToken, callOpts *bind.CallOpts) (*big.Int, error) {
+	return GetTotalSupplyMock(token, callOpts)
 }
 
 func (account AccountMock) CreateAccount(path string, password string) accounts.Account {

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -680,6 +680,10 @@ func (cmdUtils UtilsCmd) claimBounty(config types.Configurations, client *ethcli
 	return claimBounty(config, client, redeemBountyInput, utilsStruct)
 }
 
+func (cmdUtils UtilsCmd) GetAmountInSRZRs(client *ethclient.Client, address string, staker bindings.StructsStaker, amount *big.Int, utilsStruct UtilsStruct) (*big.Int, error) {
+	return GetAmountInSRZRs(client, address, staker, amount, utilsStruct)
+}
+
 func (blockManagerUtils BlockManagerUtils) ClaimBlockReward(client *ethclient.Client, opts *bind.TransactOpts) (*Types.Transaction, error) {
 	blockManager := utils.GetBlockManager(client)
 	return blockManager.ClaimBlockReward(opts)

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -275,6 +275,18 @@ func (u Utils) CalculateBlockTime(client *ethclient.Client) int64 {
 	return utils.CalculateBlockTime(client)
 }
 
+func (u Utils) GetStakedToken(client *ethclient.Client, address common.Address) *bindings.StakedToken {
+	return utils.GetStakedToken(client, address)
+}
+
+func (u Utils) ConvertSRZRToRZR(sAmount *big.Int, currentStake *big.Int, totalSupply *big.Int) *big.Int {
+	return utils.ConvertSRZRToRZR(sAmount, currentStake, totalSupply)
+}
+
+func (u Utils) ConvertRZRToSRZR(sAmount *big.Int, currentStake *big.Int, totalSupply *big.Int) (*big.Int, error) {
+	return utils.ConvertRZRToSRZR(sAmount, currentStake, totalSupply)
+}
+
 func (tokenManagerUtils TokenManagerUtils) Allowance(client *ethclient.Client, opts *bind.CallOpts, owner common.Address, spender common.Address) (*big.Int, error) {
 	tokenManager := utils.GetTokenManager(client)
 	return tokenManager.Allowance(opts, owner, spender)
@@ -353,6 +365,14 @@ func (stakeManagerUtils StakeManagerUtils) GetMaturity(client *ethclient.Client,
 func (stakeManagerUtils StakeManagerUtils) GetBountyLock(client *ethclient.Client, opts *bind.CallOpts, bountyId uint32) (types.BountyLock, error) {
 	stakeManager := utils.GetStakeManager(client)
 	return stakeManager.BountyLocks(opts, bountyId)
+}
+
+func (stakeManagerUtils StakeManagerUtils) BalanceOf(stakedToken *bindings.StakedToken, callOpts *bind.CallOpts, address common.Address) (*big.Int, error) {
+	return stakedToken.BalanceOf(callOpts, address)
+}
+
+func (stakeManagerUtils StakeManagerUtils) GetTotalSupply(token *bindings.StakedToken, callOpts *bind.CallOpts) (*big.Int, error) {
+	return token.TotalSupply(callOpts)
 }
 
 func (assetManagerUtils AssetManagerUtils) CreateJob(client *ethclient.Client, opts *bind.TransactOpts, weight uint8, power int8, selectorType uint8, name string, selector string, url string) (*Types.Transaction, error) {

--- a/cmd/unstake.go
+++ b/cmd/unstake.go
@@ -171,7 +171,7 @@ func GetAmountInSRZRs(client *ethclient.Client, address string, staker bindings.
 	}
 
 	maxUnstake := utilsStruct.razorUtils.ConvertSRZRToRZR(sRZRBalance, staker.Stake, totalSupply)
-	log.Infof("The maximum RZRs you can unstake: %f RZRs", utilsStruct.razorUtils.GetAmountInDecimal(maxUnstake))
+	log.Infof("The maximum RZRs you can unstake: %g RZRs", utilsStruct.razorUtils.GetAmountInDecimal(maxUnstake))
 
 	if maxUnstake.Cmp(amount) < 0 {
 		log.Error("Amount exceeds maximum unstake amount")

--- a/cmd/unstake.go
+++ b/cmd/unstake.go
@@ -171,7 +171,7 @@ func GetAmountInSRZRs(client *ethclient.Client, address string, staker bindings.
 	}
 
 	maxUnstake := utilsStruct.razorUtils.ConvertSRZRToRZR(sRZRBalance, staker.Stake, totalSupply)
-	log.Infof("The maximum RZRs you can unstake: %g RZRs", utilsStruct.razorUtils.GetAmountInDecimal(maxUnstake))
+	log.Debugf("The maximum RZRs you can unstake: %g RZRs", utilsStruct.razorUtils.GetAmountInDecimal(maxUnstake))
 
 	if maxUnstake.Cmp(amount) < 0 {
 		log.Error("Amount exceeds maximum unstake amount")

--- a/cmd/unstake.go
+++ b/cmd/unstake.go
@@ -101,6 +101,12 @@ func Unstake(config types.Configurations, client *ethclient.Client, input types.
 		return txnArgs, err
 	}
 
+	if lock.Amount.Cmp(big.NewInt(0)) != 0 {
+		err := errors.New("existing lock")
+		log.Error(err)
+		return txnArgs, err
+	}
+
 	staker, err := utilsStruct.razorUtils.GetStaker(client, txnArgs.AccountAddress, stakerId)
 	if err != nil {
 		log.Error("Error in getting staker: ", err)
@@ -123,7 +129,7 @@ func Unstake(config types.Configurations, client *ethclient.Client, input types.
 	}
 
 	maxUnstake := utilsStruct.razorUtils.ConvertSRZRToRZR(sRZRBalance, staker.Stake, totalSupply)
-	log.Infof("The maximum RZRs you can unstake: %f RZRs", utils.GetAmountInDecimal(maxUnstake))
+	log.Infof("The maximum RZRs you can unstake: %f RZRs", utilsStruct.razorUtils.GetAmountInDecimal(maxUnstake))
 
 	if maxUnstake.Cmp(txnArgs.Amount) < 0 {
 		log.Error("Amount exceeds maximum unstake amount")
@@ -133,12 +139,6 @@ func Unstake(config types.Configurations, client *ethclient.Client, input types.
 	sAmount, err := utilsStruct.razorUtils.ConvertRZRToSRZR(txnArgs.Amount, staker.Stake, totalSupply)
 	if err != nil {
 		log.Error("Error in getting sAmount: ", err)
-		return txnArgs, err
-	}
-
-	if lock.Amount.Cmp(big.NewInt(0)) != 0 {
-		err := errors.New("existing lock")
-		log.Error(err)
 		return txnArgs, err
 	}
 

--- a/cmd/unstake_test.go
+++ b/cmd/unstake_test.go
@@ -27,8 +27,6 @@ func TestUnstake(t *testing.T) {
 	var address string
 	var password string
 	var stakerId uint32
-	var callOpts bind.CallOpts
-	var stakedToken *bindings.StakedToken
 
 	utilsStruct := UtilsStruct{
 		razorUtils:        UtilsMock{},
@@ -38,24 +36,18 @@ func TestUnstake(t *testing.T) {
 	}
 
 	type args struct {
-		amount         *big.Int
-		lock           types.Locks
-		lockErr        error
-		epoch          uint32
-		epochErr       error
-		staker         bindings.StructsStaker
-		stakerErr      error
-		balance        *big.Int
-		balanceErr     error
-		totalSupply    *big.Int
-		totalSupplyErr error
-		RZR            *big.Int
-		decimalAmount  *big.Float
-		sRZR           *big.Int
-		sRZRErr        error
-		unstakeTxn     *Types.Transaction
-		unstakeErr     error
-		hash           common.Hash
+		amount     *big.Int
+		lock       types.Locks
+		lockErr    error
+		epoch      uint32
+		epochErr   error
+		staker     bindings.StructsStaker
+		stakerErr  error
+		sAmount    *big.Int
+		sAmountErr error
+		unstakeTxn *Types.Transaction
+		unstakeErr error
+		hash       common.Hash
 	}
 	tests := []struct {
 		name    string
@@ -68,16 +60,12 @@ func TestUnstake(t *testing.T) {
 				lock: types.Locks{
 					Amount: big.NewInt(0),
 				},
-				epoch:         5,
-				staker:        bindings.StructsStaker{},
-				balance:       big.NewInt(1000),
-				totalSupply:   big.NewInt(1000),
-				RZR:           big.NewInt(1000),
-				sRZR:          big.NewInt(1000),
-				amount:        big.NewInt(1000),
-				decimalAmount: big.NewFloat(1000),
-				unstakeTxn:    &Types.Transaction{},
-				hash:          common.BigToHash(big.NewInt(1)),
+				epoch:      5,
+				staker:     bindings.StructsStaker{},
+				amount:     big.NewInt(1000),
+				sAmount:    big.NewInt(1000),
+				unstakeTxn: &Types.Transaction{},
+				hash:       common.BigToHash(big.NewInt(1)),
 			},
 			wantErr: nil,
 		},
@@ -97,10 +85,9 @@ func TestUnstake(t *testing.T) {
 				lock: types.Locks{
 					Amount: big.NewInt(0),
 				},
-				decimalAmount: big.NewFloat(1000),
-				epochErr:      errors.New("epoch error"),
-				unstakeTxn:    &Types.Transaction{},
-				hash:          common.BigToHash(big.NewInt(1)),
+				epochErr:   errors.New("epoch error"),
+				unstakeTxn: &Types.Transaction{},
+				hash:       common.BigToHash(big.NewInt(1)),
 			},
 			wantErr: errors.New("epoch error"),
 		},
@@ -110,15 +97,10 @@ func TestUnstake(t *testing.T) {
 				lock: types.Locks{
 					Amount: big.NewInt(0),
 				},
-				epoch:         5,
-				balance:       big.NewInt(1000),
-				totalSupply:   big.NewInt(1000),
-				RZR:           big.NewInt(1000),
-				sRZR:          big.NewInt(1000),
-				amount:        big.NewInt(1000),
-				decimalAmount: big.NewFloat(1000),
-				unstakeErr:    errors.New("unstake error"),
-				hash:          common.BigToHash(big.NewInt(1)),
+				epoch:      5,
+				amount:     big.NewInt(1000),
+				unstakeErr: errors.New("unstake error"),
+				hash:       common.BigToHash(big.NewInt(1)),
 			},
 			wantErr: errors.New("unstake error"),
 		},
@@ -146,64 +128,17 @@ func TestUnstake(t *testing.T) {
 			wantErr: errors.New("staker error"),
 		},
 		{
-			name: "Test 7: When there is an error in getting sRZR balance",
+			name: "Test 7: When there is an error in getting sAmount",
 			args: args{
 				lock: types.Locks{
 					Amount: big.NewInt(0),
 				},
 				epoch:      5,
 				staker:     bindings.StructsStaker{},
-				balanceErr: errors.New("balance error"),
+				amount:     big.NewInt(1000),
+				sAmountErr: errors.New("sAmount error"),
 			},
-			wantErr: errors.New("balance error"),
-		},
-		{
-			name: "Test 8: When there is an error in getting total supply",
-			args: args{
-				lock: types.Locks{
-					Amount: big.NewInt(0),
-				},
-				epoch:          5,
-				staker:         bindings.StructsStaker{},
-				balance:        big.NewInt(1000),
-				totalSupplyErr: errors.New("totalSupply error"),
-			},
-			wantErr: errors.New("totalSupply error"),
-		},
-		{
-			name: "Test 9: When there is an error in getting sRZR",
-			args: args{
-				lock: types.Locks{
-					Amount: big.NewInt(0),
-				},
-				epoch:       5,
-				staker:      bindings.StructsStaker{},
-				balance:     big.NewInt(1000),
-				totalSupply: big.NewInt(1000),
-				RZR:         big.NewInt(1000),
-				amount:      big.NewInt(1000),
-				sRZRErr:     errors.New("sRZR error"),
-			},
-			wantErr: errors.New("sRZR error"),
-		},
-		{
-			name: "Test 10: When amount exceeds maxUnstake amount",
-			args: args{
-				lock: types.Locks{
-					Amount: big.NewInt(0),
-				},
-				epoch:         5,
-				staker:        bindings.StructsStaker{},
-				balance:       big.NewInt(1000),
-				totalSupply:   big.NewInt(1000),
-				RZR:           big.NewInt(1000),
-				sRZR:          big.NewInt(1000),
-				amount:        big.NewInt(2000),
-				decimalAmount: big.NewFloat(1000),
-				unstakeTxn:    &Types.Transaction{},
-				hash:          common.BigToHash(big.NewInt(1)),
-			},
-			wantErr: errors.New("invalid amount"),
+			wantErr: errors.New("sAmount error"),
 		},
 	}
 	for _, tt := range tests {
@@ -216,40 +151,16 @@ func TestUnstake(t *testing.T) {
 				return tt.args.staker, tt.args.stakerErr
 			}
 
-			GetStakedTokenMock = func(*ethclient.Client, common.Address) *bindings.StakedToken {
-				return stakedToken
-			}
-
-			GetOptionsMock = func(bool, string, string) bind.CallOpts {
-				return callOpts
-			}
-
-			BalanceOfMock = func(*bindings.StakedToken, *bind.CallOpts, common.Address) (*big.Int, error) {
-				return tt.args.balance, tt.args.balanceErr
-			}
-
-			GetTotalSupplyMock = func(*bindings.StakedToken, *bind.CallOpts) (*big.Int, error) {
-				return tt.args.totalSupply, tt.args.totalSupplyErr
-			}
-
-			ConvertSRZRToRZRMock = func(*big.Int, *big.Int, *big.Int) *big.Int {
-				return tt.args.RZR
-			}
-
-			GetAmountInDecimalMock = func(*big.Int) *big.Float {
-				return tt.args.decimalAmount
-			}
-
-			ConvertRZRToSRZRMock = func(*big.Int, *big.Int, *big.Int) (*big.Int, error) {
-				return tt.args.sRZR, tt.args.sRZRErr
-			}
-
 			WaitForAppropriateStateMock = func(*ethclient.Client, string, string, UtilsStruct, ...int) (uint32, error) {
 				return tt.args.epoch, tt.args.epochErr
 			}
 
 			GetTxnOptsMock = func(types.TransactionOptions) *bind.TransactOpts {
 				return txnOpts
+			}
+
+			GetAmountInSRZRsMock = func(*ethclient.Client, string, bindings.StructsStaker, *big.Int, UtilsStruct) (*big.Int, error) {
+				return tt.args.sAmount, tt.args.sAmountErr
 			}
 
 			UnstakeContractMock = func(*ethclient.Client, *bind.TransactOpts, uint32, uint32, *big.Int) (*Types.Transaction, error) {
@@ -560,6 +471,157 @@ func TestAutoWithdraw(t *testing.T) {
 					t.Errorf("Error for AutoWithdraw function, got = %v, want = %v", gotErr, tt.wantErr)
 				}
 			}
+		})
+	}
+}
+
+func TestGetAmountInSRZRs(t *testing.T) {
+	var client *ethclient.Client
+	var address string
+	var callOpts bind.CallOpts
+	var stakedToken *bindings.StakedToken
+
+	utilsStruct := UtilsStruct{
+		razorUtils:        UtilsMock{},
+		stakeManagerUtils: StakeManagerMock{},
+	}
+
+	type args struct {
+		staker         bindings.StructsStaker
+		amount         *big.Int
+		balance        *big.Int
+		balanceErr     error
+		totalSupply    *big.Int
+		totalSupplyErr error
+		RZR            *big.Int
+		decimalAmount  *big.Float
+		sRZR           *big.Int
+		sRZRErr        error
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *big.Int
+		wantErr error
+	}{
+		{
+			name: "Test 1: When GetAmountInSRZRs executes successfully",
+			args: args{
+				staker: bindings.StructsStaker{
+					Stake: big.NewInt(1000),
+				},
+				amount:        big.NewInt(1000),
+				balance:       big.NewInt(1000),
+				totalSupply:   big.NewInt(1000),
+				RZR:           big.NewInt(1000),
+				decimalAmount: big.NewFloat(1000),
+				sRZR:          big.NewInt(1000),
+			},
+			want:    big.NewInt(1000),
+			wantErr: nil,
+		},
+		{
+			name: "Test 2: When there is an error in getting sRZR balance",
+			args: args{
+				staker: bindings.StructsStaker{
+					Stake: big.NewInt(1000),
+				},
+				amount:     big.NewInt(1000),
+				balanceErr: errors.New("sRZR balance error"),
+			},
+			want:    nil,
+			wantErr: errors.New("sRZR balance error"),
+		},
+		{
+			name: "Test 3: When there is an error in getting total supply of sRZR",
+			args: args{
+				staker: bindings.StructsStaker{
+					Stake: big.NewInt(1000),
+				},
+				amount:         big.NewInt(1000),
+				balance:        big.NewInt(1000),
+				totalSupplyErr: errors.New("totalSupply error"),
+			},
+			want:    nil,
+			wantErr: errors.New("totalSupply error"),
+		},
+		{
+			name: "Test 4: When input amount exceeds total sRZR balance",
+			args: args{
+				staker: bindings.StructsStaker{
+					Stake: big.NewInt(1000),
+				},
+				amount:        big.NewInt(2000),
+				balance:       big.NewInt(1000),
+				totalSupply:   big.NewInt(1000),
+				RZR:           big.NewInt(1000),
+				decimalAmount: big.NewFloat(1000),
+				sRZR:          big.NewInt(1000),
+			},
+			want:    nil,
+			wantErr: errors.New("invalid amount"),
+		},
+		{
+			name: "Test 5: When there is an error in converting RZR's to sRZR's",
+			args: args{
+				staker: bindings.StructsStaker{
+					Stake: big.NewInt(1000),
+				},
+				amount:        big.NewInt(1000),
+				balance:       big.NewInt(1000),
+				totalSupply:   big.NewInt(1000),
+				RZR:           big.NewInt(1000),
+				decimalAmount: big.NewFloat(1000),
+				sRZRErr:       errors.New("conversion RZR to sRZR error"),
+			},
+			want:    nil,
+			wantErr: errors.New("conversion RZR to sRZR error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			GetStakedTokenMock = func(*ethclient.Client, common.Address) *bindings.StakedToken {
+				return stakedToken
+			}
+
+			GetOptionsMock = func() bind.CallOpts {
+				return callOpts
+			}
+
+			BalanceOfMock = func(*bindings.StakedToken, *bind.CallOpts, common.Address) (*big.Int, error) {
+				return tt.args.balance, tt.args.balanceErr
+			}
+
+			GetTotalSupplyMock = func(*bindings.StakedToken, *bind.CallOpts) (*big.Int, error) {
+				return tt.args.totalSupply, tt.args.totalSupplyErr
+			}
+
+			ConvertSRZRToRZRMock = func(*big.Int, *big.Int, *big.Int) *big.Int {
+				return tt.args.RZR
+			}
+
+			GetAmountInDecimalMock = func(*big.Int) *big.Float {
+				return tt.args.decimalAmount
+			}
+
+			ConvertRZRToSRZRMock = func(*big.Int, *big.Int, *big.Int) (*big.Int, error) {
+				return tt.args.sRZR, tt.args.sRZRErr
+			}
+
+			got, err := GetAmountInSRZRs(client, address, tt.args.staker, tt.args.amount, utilsStruct)
+			if got.Cmp(tt.want) != 0 {
+				t.Errorf("GetAmountInSRZRs() = %v, want = %v", got, tt.want)
+			}
+			if err == nil || tt.wantErr == nil {
+				if err != tt.wantErr {
+					t.Errorf("Error for GetAmountInSRZRs function, got = %v, want = %v", err, tt.wantErr)
+				}
+			} else {
+				if err.Error() != tt.wantErr.Error() {
+					t.Errorf("Error for GetAmountInSRZRs function, got = %v, want = %v", err, tt.wantErr)
+				}
+			}
+
 		})
 	}
 }

--- a/cmd/unstake_test.go
+++ b/cmd/unstake_test.go
@@ -577,6 +577,22 @@ func TestGetAmountInSRZRs(t *testing.T) {
 			want:    nil,
 			wantErr: errors.New("conversion RZR to sRZR error"),
 		},
+		{
+			name: "Test 6: When the supply is high and GetAmountInSRZRs executes successfully",
+			args: args{
+				staker: bindings.StructsStaker{
+					Stake: big.NewInt(1).Exp(big.NewInt(10), big.NewInt(9), nil),
+				},
+				amount:        big.NewInt(1).Exp(big.NewInt(10), big.NewInt(6), nil),
+				balance:       big.NewInt(1).Exp(big.NewInt(10), big.NewInt(7), nil),
+				totalSupply:   big.NewInt(1).Exp(big.NewInt(10), big.NewInt(9), nil),
+				RZR:           big.NewInt(1).Exp(big.NewInt(10), big.NewInt(7), nil),
+				decimalAmount: big.NewFloat(1).Mul(big.NewFloat(10), big.NewFloat(1e5)),
+				sRZR:          big.NewInt(1).Exp(big.NewInt(10), big.NewInt(6), nil),
+			},
+			want:    big.NewInt(1).Exp(big.NewInt(10), big.NewInt(6), nil),
+			wantErr: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/generate-bindings.sh
+++ b/generate-bindings.sh
@@ -24,6 +24,7 @@ contracts=(
   "RAZOR RAZOR.go"
   "StakeManager stakeManager.go"
   "StakeStorage stakeStorage.go"
+  "StakedToken stakedToken.go"
   "VoteManager voteManager.go"
   "VoteStorage voteStorage.go"
 )

--- a/utils/contract-manager.go
+++ b/utils/contract-manager.go
@@ -48,3 +48,11 @@ func GetBlockManager(client *ethclient.Client) *bindings.BlockManager {
 	}
 	return blockManager
 }
+
+func GetStakedToken(client *ethclient.Client, tokenAddress common.Address) *bindings.StakedToken {
+	stakedTokenContract, err := bindings.NewStakedToken(tokenAddress, client)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return stakedTokenContract
+}

--- a/utils/math.go
+++ b/utils/math.go
@@ -149,3 +149,14 @@ func ConvertWeiToEth(data *big.Int) (*big.Float, error) {
 	dataInFloat := new(big.Float).SetInt(data)
 	return dataInFloat.Quo(dataInFloat, big.NewFloat(1e18)).SetPrec(32), nil
 }
+
+func ConvertRZRToSRZR(amount *big.Int, currentStake *big.Int, totalSupply *big.Int) (*big.Int, error) {
+	if currentStake.Cmp(big.NewInt(0)) == 0 {
+		return big.NewInt(0), errors.New("current stake is 0")
+	}
+	return big.NewInt(1).Div(big.NewInt(1).Mul(amount, totalSupply), currentStake), nil
+}
+
+func ConvertSRZRToRZR(sAmount *big.Int, currentStake *big.Int, totalSupply *big.Int) *big.Int {
+	return big.NewInt(1).Div(big.NewInt(1).Mul(sAmount, currentStake), totalSupply)
+}

--- a/utils/math_test.go
+++ b/utils/math_test.go
@@ -837,6 +837,16 @@ func TestConvertRZRToSRZR(t *testing.T) {
 			want:    big.NewInt(0),
 			wantErr: true,
 		},
+		{
+			name: "Test 4: When values are high",
+			args: args{
+				amount:       big.NewInt(1).Mul(big.NewInt(500), big.NewInt(1e7)),
+				currentStake: big.NewInt(1).Mul(big.NewInt(400), big.NewInt(1e8)),
+				totalSupply:  big.NewInt(1).Mul(big.NewInt(4000), big.NewInt(1e8)),
+			},
+			want:    big.NewInt(1).Mul(big.NewInt(500), big.NewInt(1e8)),
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -880,6 +890,15 @@ func TestConvertSRZRToRZR(t *testing.T) {
 				totalSupply:  big.NewInt(1000),
 			},
 			want: big.NewInt(1000),
+		},
+		{
+			name: "Test 3: When values are high",
+			args: args{
+				sAmount:      big.NewInt(1).Mul(big.NewInt(500), big.NewInt(1e8)),
+				currentStake: big.NewInt(1).Mul(big.NewInt(400), big.NewInt(1e8)),
+				totalSupply:  big.NewInt(1).Mul(big.NewInt(4000), big.NewInt(1e8)),
+			},
+			want: big.NewInt(1).Mul(big.NewInt(500), big.NewInt(1e7)),
 		},
 	}
 	for _, tt := range tests {

--- a/utils/math_test.go
+++ b/utils/math_test.go
@@ -794,3 +794,99 @@ func Test_getFractionalWeight(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertRZRToSRZR(t *testing.T) {
+	type args struct {
+		amount       *big.Int
+		currentStake *big.Int
+		totalSupply  *big.Int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *big.Int
+		wantErr bool
+	}{
+		{
+			name: "Test 1: When currentStake and totalSupply are equal",
+			args: args{
+				amount:       big.NewInt(500),
+				currentStake: big.NewInt(2000),
+				totalSupply:  big.NewInt(2000),
+			},
+			want:    big.NewInt(500),
+			wantErr: false,
+		},
+		{
+			name: "Test 2: When totalSupply < currentStake ",
+			args: args{
+				amount:       big.NewInt(500),
+				currentStake: big.NewInt(4000),
+				totalSupply:  big.NewInt(2000),
+			},
+			want:    big.NewInt(250),
+			wantErr: false,
+		},
+		{
+			name: "Test 3: When currentStake is 0",
+			args: args{
+				amount:       big.NewInt(500),
+				currentStake: big.NewInt(0),
+				totalSupply:  big.NewInt(2000),
+			},
+			want:    big.NewInt(0),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertRZRToSRZR(tt.args.amount, tt.args.currentStake, tt.args.totalSupply)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertRZRToSRZR() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got.Cmp(tt.want) != 0 {
+				t.Errorf("ConvertRZRToSRZR() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertSRZRToRZR(t *testing.T) {
+	type args struct {
+		sAmount      *big.Int
+		currentStake *big.Int
+		totalSupply  *big.Int
+	}
+	tests := []struct {
+		name string
+		args args
+		want *big.Int
+	}{
+		{
+			name: "Test 1: When current stake totalSupply are equal",
+			args: args{
+				sAmount:      big.NewInt(500),
+				currentStake: big.NewInt(1000),
+				totalSupply:  big.NewInt(1000),
+			},
+			want: big.NewInt(500),
+		},
+		{
+			name: "Test 2: When totalSupply < currentStake",
+			args: args{
+				sAmount:      big.NewInt(500),
+				currentStake: big.NewInt(2000),
+				totalSupply:  big.NewInt(1000),
+			},
+			want: big.NewInt(1000),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ConvertSRZRToRZR(tt.args.sAmount, tt.args.currentStake, tt.args.totalSupply); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ConvertSRZRToRZR() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

The input value for unstake is considered in RZR's and than it is converted into its equivalent sRZR's that is passed as parameter to unstake contract call.

Fixes #376

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules