### PR TITLE
Display warning before killing the vote process.

### DIFF
--- a/cmd/stake.go
+++ b/cmd/stake.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"razor/core"
 	"razor/core/types"
 	"razor/pkg/bindings"
@@ -85,7 +86,7 @@ Example:
 					IsRogue:   isRogue,
 					RogueMode: rogueMode,
 				}
-				utilsStruct.vote(config, client, rogueData, account)
+				utilsStruct.vote(context.Background(), config, client, rogueData, account)
 			}
 		}
 	},

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"github.com/spf13/pflag"
 	"math/big"
 	"os"
+	"os/signal"
 	"razor/accounts"
 	"razor/core"
 	"razor/core/types"
@@ -60,23 +62,52 @@ func (utilsStruct UtilsStruct) executeVote(flagSet *pflag.FlagSet) {
 	client := utils.ConnectToClient(config.Provider)
 	address, _ := flagSet.GetString("address")
 	account := types.Account{Address: address, Password: password}
-	utilsStruct.vote(config, client, rogueData, account)
 
+	// listen for CTRL+C
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt)
+
+	defer func() {
+		signal.Stop(signalChan)
+		cancel()
+	}()
+
+	go func() {
+		select {
+		case <-signalChan:
+			log.Warn("If you don't unstake and withdraw your coins, you may get inactivity penalty!")
+		case <-ctx.Done():
+		}
+		<-signalChan // second signal, hard exit
+		os.Exit(2)
+	}()
+
+	if err := utilsStruct.vote(ctx, config, client, rogueData, account); err != nil {
+		log.Error(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
 }
 
-func (utilsStruct UtilsStruct) vote(config types.Configurations, client *ethclient.Client, rogueData types.Rogue, account types.Account) {
+func (utilsStruct UtilsStruct) vote(ctx context.Context, config types.Configurations, client *ethclient.Client, rogueData types.Rogue, account types.Account) error {
+
 	header, err := razorUtils.GetLatestBlock(client)
 	utils.CheckError("Error in getting block: ", err)
-
 	for {
-		latestHeader, err := utils.UtilsInterface.GetLatestBlockWithRetry(client)
-		if err != nil {
-			log.Error("Error in fetching block: ", err)
-			continue
-		}
-		if latestHeader.Number.Cmp(header.Number) != 0 {
-			header = latestHeader
-			handleBlock(client, account, latestHeader.Number, config, rogueData, utilsStruct)
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			latestHeader, err := utils.UtilsInterface.GetLatestBlockWithRetry(client)
+			if err != nil {
+				log.Error("Error in fetching block: ", err)
+				continue
+			}
+			if latestHeader.Number.Cmp(header.Number) != 0 {
+				header = latestHeader
+				handleBlock(client, account, latestHeader.Number, config, rogueData, utilsStruct)
+			}
 		}
 	}
 }

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -85,7 +85,7 @@ func (utilsStruct UtilsStruct) executeVote(flagSet *pflag.FlagSet) {
 	}()
 
 	if err := utilsStruct.vote(ctx, config, client, rogueData, account); err != nil {
-		log.Error(os.Stderr, "%s\n", err)
+		log.Errorf("%s\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
# Description

When the user presses `CTRL+C` first a warning is displayed and on the 2nd press of `CTRL+C`, the execution stops

Fixes #132 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Tested on my local hardhat

**Test Configuration**:
* Contracts version: `v0.1.81`
* Hardware: Macbook air M1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules