### PR TITLE
Set delegation hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,13 @@ $ ./razor stakerInfo --stakerId 2
 If you are a staker you can accept delegation from delegators and charge a commission from them.
 
 ```
-$ ./razor setDelegation --address <address> --status <true_or_false>
+$ ./razor setDelegation --address <address> --status <true_or_false> --commission <commission_percent>
 ```
 
 Example:
 
 ```
-$ ./razor setDelegation --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --status true
+$ ./razor setDelegation --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --status true -c 20
 ```
 
 ### Update Commission

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -184,6 +184,7 @@ type utilsCmdInterface interface {
 	Create(string, UtilsStruct) (accounts.Account, error)
 	claimBounty(types.Configurations, *ethclient.Client, types.RedeemBountyInput, UtilsStruct) (common.Hash, error)
 	GetAmountInSRZRs(*ethclient.Client, string, bindings.StructsStaker, *big.Int, UtilsStruct) (*big.Int, error)
+	ExecuteUpdateCommission(client *ethclient.Client, input types.UpdateCommissionInput, utilsStruct UtilsStruct) error
 }
 
 type cryptoInterface interface {

--- a/cmd/mock.go
+++ b/cmd/mock.go
@@ -293,6 +293,8 @@ var claimBountyMock func(types.Configurations, *ethclient.Client, types.RedeemBo
 
 var GetAmountInSRZRsMock func(*ethclient.Client, string, bindings.StructsStaker, *big.Int, UtilsStruct) (*big.Int, error)
 
+var ExecuteUpdateCommissionMock func(*ethclient.Client, types.UpdateCommissionInput, UtilsStruct) error
+
 var UnstakeMock func(types.Configurations, *ethclient.Client, types.UnstakeInput, UtilsStruct) (types.TransactionOptions, error)
 
 var withdrawFundsMock func(*ethclient.Client, types.Account, types.Configurations, uint32, UtilsStruct) (common.Hash, error)
@@ -992,6 +994,10 @@ func (utilsCmdMock UtilsCmdMock) claimBounty(config types.Configurations, client
 
 func (utilsCmdMock UtilsCmdMock) GetAmountInSRZRs(client *ethclient.Client, address string, staker bindings.StructsStaker, amount *big.Int, utilsStruct UtilsStruct) (*big.Int, error) {
 	return GetAmountInSRZRsMock(client, address, staker, amount, utilsStruct)
+}
+
+func (utilsCmdMock UtilsCmdMock) ExecuteUpdateCommission(client *ethclient.Client, input types.UpdateCommissionInput, utilsStruct UtilsStruct) error {
+	return ExecuteUpdateCommissionMock(client, input, utilsStruct)
 }
 
 func (blockManagerMock BlockManagerMock) ClaimBlockReward(client *ethclient.Client, opts *bind.TransactOpts) (*Types.Transaction, error) {

--- a/cmd/setDelegation.go
+++ b/cmd/setDelegation.go
@@ -71,7 +71,7 @@ func (utilsStruct UtilsStruct) SetDelegation(flagSet *pflag.FlagSet) error {
 		return err
 	}
 	if commission != 0 {
-		err = executeUpdateCommission(client, types.UpdateCommissionInput{
+		err = utilsStruct.cmdUtils.ExecuteUpdateCommission(client, types.UpdateCommissionInput{
 			StakerId:   stakerId,
 			Address:    address,
 			Password:   password,

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -753,6 +753,10 @@ func (cmdUtils UtilsCmd) GetAmountInSRZRs(client *ethclient.Client, address stri
 	return GetAmountInSRZRs(client, address, staker, amount, utilsStruct)
 }
 
+func (cmdUtils UtilsCmd) ExecuteUpdateCommission(client *ethclient.Client, input types.UpdateCommissionInput, utilsStruct UtilsStruct) error {
+	return ExecuteUpdateCommission(client, input, utilsStruct)
+}
+
 func (blockManagerUtils BlockManagerUtils) ClaimBlockReward(client *ethclient.Client, opts *bind.TransactOpts) (*Types.Transaction, error) {
 	blockManager := utils.UtilsInterface.GetBlockManager(client)
 	return blockManager.ClaimBlockReward(opts)

--- a/cmd/updateCommission.go
+++ b/cmd/updateCommission.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/spf13/pflag"
 	"razor/core"
 	"razor/core/types"
@@ -54,7 +55,17 @@ func (utilsStruct UtilsStruct) UpdateCommission(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	stakerInfo, err := utilsStruct.razorUtils.GetStaker(client, address, stakerId)
+	return executeUpdateCommission(client, types.UpdateCommissionInput{
+		Commission: commission,
+		Config:     config,
+		Address:    address,
+		Password:   password,
+		StakerId:   stakerId,
+	}, utilsStruct)
+}
+
+func executeUpdateCommission(client *ethclient.Client, input types.UpdateCommissionInput, utilsStruct UtilsStruct) error {
+	stakerInfo, err := utilsStruct.razorUtils.GetStaker(client, input.Address, input.StakerId)
 	if err != nil {
 		log.Error("Error in fetching staker info")
 		return err
@@ -65,7 +76,7 @@ func (utilsStruct UtilsStruct) UpdateCommission(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if commission == 0 || commission > maxCommission {
+	if input.Commission == 0 || input.Commission > maxCommission {
 		return errors.New("commission out of range")
 	}
 
@@ -82,22 +93,20 @@ func (utilsStruct UtilsStruct) UpdateCommission(flagSet *pflag.FlagSet) error {
 	if stakerInfo.EpochCommissionLastUpdated != 0 && (stakerInfo.EpochCommissionLastUpdated+uint32(epochLimitForUpdateCommission)) >= epoch {
 		return errors.New("invalid epoch for update")
 	}
-
 	txnOpts := types.TransactionOptions{
 		Client:          client,
-		Password:        password,
-		AccountAddress:  address,
+		Password:        input.Password,
+		AccountAddress:  input.Address,
 		ChainId:         core.ChainId,
-		Config:          config,
+		Config:          input.Config,
 		ContractAddress: core.StakeManagerAddress,
 		ABI:             bindings.StakeManagerABI,
 		MethodName:      "updateCommission",
-		Parameters:      []interface{}{commission},
+		Parameters:      []interface{}{input.Commission},
 	}
-
 	updateCommissionTxnOpts := utilsStruct.razorUtils.GetTxnOpts(txnOpts)
-	log.Infof("Setting the commission value of Staker %d to %d%%", stakerId, commission)
-	txn, err := utilsStruct.stakeManagerUtils.UpdateCommission(client, updateCommissionTxnOpts, commission)
+	log.Infof("Setting the commission value of Staker %d to %d%%", input.StakerId, input.Commission)
+	txn, err := utilsStruct.stakeManagerUtils.UpdateCommission(client, updateCommissionTxnOpts, input.Commission)
 	if err != nil {
 		log.Error("Error in setting commission")
 		return err

--- a/cmd/updateCommission.go
+++ b/cmd/updateCommission.go
@@ -55,7 +55,7 @@ func (utilsStruct UtilsStruct) UpdateCommission(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	return executeUpdateCommission(client, types.UpdateCommissionInput{
+	return utilsStruct.cmdUtils.ExecuteUpdateCommission(client, types.UpdateCommissionInput{
 		Commission: commission,
 		Config:     config,
 		Address:    address,
@@ -64,7 +64,7 @@ func (utilsStruct UtilsStruct) UpdateCommission(flagSet *pflag.FlagSet) error {
 	}, utilsStruct)
 }
 
-func executeUpdateCommission(client *ethclient.Client, input types.UpdateCommissionInput, utilsStruct UtilsStruct) error {
+func ExecuteUpdateCommission(client *ethclient.Client, input types.UpdateCommissionInput, utilsStruct UtilsStruct) error {
 	stakerInfo, err := utilsStruct.razorUtils.GetStaker(client, input.Address, input.StakerId)
 	if err != nil {
 		log.Error("Error in fetching staker info")

--- a/cmd/updateCommission_test.go
+++ b/cmd/updateCommission_test.go
@@ -26,8 +26,157 @@ func TestUtilsStruct_UpdateCommission(t *testing.T) {
 		WaitTime:      1,
 	}
 
+	utilsStruct := UtilsStruct{
+		razorUtils:        UtilsMock{},
+		stakeManagerUtils: StakeManagerMock{},
+		transactionUtils:  TransactionMock{},
+		flagSetUtils:      FlagSetMock{},
+		cmdUtils:          UtilsCmdMock{},
+	}
+
+	type args struct {
+		config              types.Configurations
+		configErr           error
+		password            string
+		address             string
+		addressErr          error
+		commission          uint8
+		commissionErr       error
+		stakerId            uint32
+		stakerIdErr         error
+		UpdateCommissionErr error
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name: "Test 1: When update commission executes successfully",
+			args: args{
+				config:              config,
+				password:            "test",
+				address:             "0x000000000000000000000000000000000000dea1",
+				commission:          10,
+				stakerId:            1,
+				UpdateCommissionErr: nil,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Test 2: When there is an error in fetching config",
+			args: args{
+				config:              types.Configurations{},
+				configErr:           errors.New("error in getting config"),
+				password:            "test",
+				address:             "0x000000000000000000000000000000000000dea1",
+				commission:          10,
+				stakerId:            1,
+				UpdateCommissionErr: nil,
+			},
+			wantErr: errors.New("error in getting config"),
+		},
+		{
+			name: "Test 3: When there is an error in fetching address",
+			args: args{
+				config:              config,
+				password:            "test",
+				address:             "",
+				addressErr:          errors.New("error in fetching address"),
+				commission:          10,
+				stakerId:            1,
+				UpdateCommissionErr: nil,
+			},
+			wantErr: errors.New("error in fetching address"),
+		},
+		{
+			name: "Test 4: When there is an error in fetching commission",
+			args: args{
+				config:              config,
+				password:            "test",
+				address:             "0x000000000000000000000000000000000000dea1",
+				commission:          0,
+				commissionErr:       errors.New("error in fetching commission"),
+				stakerId:            1,
+				UpdateCommissionErr: nil,
+			},
+			wantErr: errors.New("error in fetching commission"),
+		},
+		{
+			name: "Test 5: When there is an error in fetching stakerId",
+			args: args{
+				config:              config,
+				password:            "test",
+				address:             "0x000000000000000000000000000000000000dea1",
+				commission:          10,
+				stakerId:            0,
+				stakerIdErr:         errors.New("error in fetching the stakerId"),
+				UpdateCommissionErr: nil,
+			},
+			wantErr: errors.New("error in fetching the stakerId"),
+		},
+		{
+			name: "Test 6: When there is an error in executing update commission",
+			args: args{
+				config:              config,
+				password:            "test",
+				address:             "0x000000000000000000000000000000000000dea1",
+				commission:          10,
+				stakerId:            0,
+				UpdateCommissionErr: errors.New("error in ExecuteUpdateCommission"),
+			},
+			wantErr: errors.New("error in ExecuteUpdateCommission"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			GetConfigDataMock = func(UtilsStruct) (types.Configurations, error) {
+				return tt.args.config, tt.args.configErr
+			}
+			AssignPasswordMock = func(set *pflag.FlagSet) string {
+				return tt.args.password
+			}
+			GetStringAddressMock = func(*pflag.FlagSet) (string, error) {
+				return tt.args.address, tt.args.addressErr
+			}
+			GetUint8CommissionMock = func(*pflag.FlagSet) (uint8, error) {
+				return tt.args.commission, tt.args.commissionErr
+			}
+			GetStakerIdMock = func(*ethclient.Client, string) (uint32, error) {
+				return tt.args.stakerId, tt.args.stakerIdErr
+			}
+			ConnectToClientMock = func(string2 string) *ethclient.Client {
+				return client
+			}
+			ExecuteUpdateCommissionMock = func(*ethclient.Client, types.UpdateCommissionInput, UtilsStruct) error {
+				return tt.args.UpdateCommissionErr
+			}
+			gotErr := utilsStruct.UpdateCommission(flagSet)
+			if gotErr == nil || tt.wantErr == nil {
+				if gotErr != tt.wantErr {
+					t.Errorf("Error for UpdateCommission function, got = %v, want = %v", gotErr, tt.wantErr)
+				}
+			} else {
+				if gotErr.Error() != tt.wantErr.Error() {
+					t.Errorf("Error for UpdateCommission function, got = %v, want = %v", gotErr, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func Test_executeUpdateCommission(t *testing.T) {
+
+	var client *ethclient.Client
 	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
+	var config = types.Configurations{
+		Provider:      "127.0.0.1",
+		GasMultiplier: 1,
+		BufferPercent: 20,
+		WaitTime:      1,
+	}
 
 	utilsStruct := UtilsStruct{
 		razorUtils:        UtilsMock{},
@@ -38,15 +187,8 @@ func TestUtilsStruct_UpdateCommission(t *testing.T) {
 	}
 
 	type args struct {
-		config                           types.Configurations
-		configErr                        error
-		password                         string
-		address                          string
-		addressErr                       error
-		commission                       uint8
-		commissionErr                    error
-		stakerId                         uint32
-		stakerIdErr                      error
+		client                           *ethclient.Client
+		input                            types.UpdateCommissionInput
 		stakerInfo                       bindings.StructsStaker
 		stakerInfoErr                    error
 		maxCommission                    uint8
@@ -60,7 +202,6 @@ func TestUtilsStruct_UpdateCommission(t *testing.T) {
 		WaitForBlockCompletionStatus     int
 		hash                             common.Hash
 	}
-
 	tests := []struct {
 		name    string
 		args    args
@@ -69,11 +210,14 @@ func TestUtilsStruct_UpdateCommission(t *testing.T) {
 		{
 			name: "Test 1: When update commission executes successfully",
 			args: args{
-				config:                        config,
-				password:                      "test",
-				address:                       "0x000000000000000000000000000000000000dea1",
-				commission:                    10,
-				stakerId:                      1,
+				input: types.UpdateCommissionInput{
+					StakerId:   1,
+					Address:    "0x000000000000000000000000000000000000dea1",
+					Password:   "test",
+					Commission: 10,
+					Config:     config,
+				},
+				client:                        client,
 				stakerInfo:                    bindings.StructsStaker{},
 				maxCommission:                 20,
 				epochLimitForUpdateCommission: 10,
@@ -85,89 +229,15 @@ func TestUtilsStruct_UpdateCommission(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "Test 2: When there is an error in fetching config",
+			name: "Test 2: When there is an error in fetching staker info",
 			args: args{
-				config:                        types.Configurations{},
-				configErr:                     errors.New("error in getting config"),
-				password:                      "test",
-				address:                       "0x000000000000000000000000000000000000dea1",
-				commission:                    10,
-				stakerId:                      1,
-				stakerInfo:                    bindings.StructsStaker{},
-				maxCommission:                 20,
-				epochLimitForUpdateCommission: 10,
-				epoch:                         11,
-				UpdateCommissionTxn:           &Types.Transaction{},
-				UpdateCommissionErr:           nil,
-				WaitForBlockCompletionStatus:  1,
-			},
-			wantErr: errors.New("error in getting config"),
-		},
-		{
-			name: "Test 3: When there is an error in fetching address",
-			args: args{
-				config:                        config,
-				password:                      "test",
-				address:                       "",
-				addressErr:                    errors.New("error in fetching address"),
-				commission:                    10,
-				stakerId:                      1,
-				stakerInfo:                    bindings.StructsStaker{},
-				maxCommission:                 20,
-				epochLimitForUpdateCommission: 10,
-				epoch:                         11,
-				UpdateCommissionTxn:           &Types.Transaction{},
-				UpdateCommissionErr:           nil,
-				WaitForBlockCompletionStatus:  1,
-			},
-			wantErr: errors.New("error in fetching address"),
-		},
-		{
-			name: "Test 4: When there is an error in fetching commission",
-			args: args{
-				config:                        config,
-				password:                      "test",
-				address:                       "0x000000000000000000000000000000000000dea1",
-				commission:                    0,
-				commissionErr:                 errors.New("error in fetching commission"),
-				stakerId:                      1,
-				stakerInfo:                    bindings.StructsStaker{},
-				maxCommission:                 20,
-				epochLimitForUpdateCommission: 10,
-				epoch:                         11,
-				UpdateCommissionTxn:           &Types.Transaction{},
-				UpdateCommissionErr:           nil,
-				WaitForBlockCompletionStatus:  1,
-			},
-			wantErr: errors.New("error in fetching commission"),
-		},
-		{
-			name: "Test 5: When there is an error in fetching stakerId",
-			args: args{
-				config:                        config,
-				password:                      "test",
-				address:                       "0x000000000000000000000000000000000000dea1",
-				commission:                    10,
-				stakerId:                      0,
-				stakerIdErr:                   errors.New("error in fetching the stakerId"),
-				stakerInfo:                    bindings.StructsStaker{},
-				maxCommission:                 20,
-				epochLimitForUpdateCommission: 10,
-				epoch:                         11,
-				UpdateCommissionTxn:           &Types.Transaction{},
-				UpdateCommissionErr:           nil,
-				WaitForBlockCompletionStatus:  1,
-			},
-			wantErr: errors.New("error in fetching the stakerId"),
-		},
-		{
-			name: "Test 6: When there is an error in fetching staker info",
-			args: args{
-				config:                        config,
-				password:                      "test",
-				address:                       "0x000000000000000000000000000000000000dea1",
-				commission:                    10,
-				stakerId:                      1,
+				input: types.UpdateCommissionInput{
+					StakerId:   1,
+					Address:    "0x000000000000000000000000000000000000dea1",
+					Password:   "test",
+					Commission: 10,
+					Config:     config,
+				},
 				stakerInfo:                    bindings.StructsStaker{},
 				stakerInfoErr:                 errors.New("error in fetching stakerInfo"),
 				maxCommission:                 20,
@@ -180,13 +250,15 @@ func TestUtilsStruct_UpdateCommission(t *testing.T) {
 			wantErr: errors.New("error in fetching stakerInfo"),
 		},
 		{
-			name: "Test 7: When there is an error in fetching max commission",
+			name: "Test 3: When there is an error in fetching max commission",
 			args: args{
-				config:                        config,
-				password:                      "test",
-				address:                       "0x000000000000000000000000000000000000dea1",
-				commission:                    10,
-				stakerId:                      1,
+				input: types.UpdateCommissionInput{
+					StakerId:   1,
+					Address:    "0x000000000000000000000000000000000000dea1",
+					Password:   "test",
+					Commission: 10,
+					Config:     config,
+				},
 				stakerInfo:                    bindings.StructsStaker{},
 				maxCommission:                 0,
 				maxCommissionErr:              errors.New("error in fetching max commission"),
@@ -199,13 +271,15 @@ func TestUtilsStruct_UpdateCommission(t *testing.T) {
 			wantErr: errors.New("error in fetching max commission"),
 		},
 		{
-			name: "Test 8: When there is an error in fetching epochLimitForUpdateCommission",
+			name: "Test 4: When there is an error in fetching epochLimitForUpdateCommission",
 			args: args{
-				config:                           config,
-				password:                         "test",
-				address:                          "0x000000000000000000000000000000000000dea1",
-				commission:                       10,
-				stakerId:                         1,
+				input: types.UpdateCommissionInput{
+					StakerId:   1,
+					Address:    "0x000000000000000000000000000000000000dea1",
+					Password:   "test",
+					Commission: 10,
+					Config:     config,
+				},
 				stakerInfo:                       bindings.StructsStaker{},
 				maxCommission:                    20,
 				maxCommissionErr:                 nil,
@@ -219,13 +293,15 @@ func TestUtilsStruct_UpdateCommission(t *testing.T) {
 			wantErr: errors.New("error in fetching epochLimitForUpdateCommission"),
 		},
 		{
-			name: "Test 9: When there is an error in fetching epoch",
+			name: "Test 5: When there is an error in fetching epoch",
 			args: args{
-				config:                        config,
-				password:                      "test",
-				address:                       "0x000000000000000000000000000000000000dea1",
-				commission:                    10,
-				stakerId:                      1,
+				input: types.UpdateCommissionInput{
+					StakerId:   1,
+					Address:    "0x000000000000000000000000000000000000dea1",
+					Password:   "test",
+					Commission: 10,
+					Config:     config,
+				},
 				stakerInfo:                    bindings.StructsStaker{},
 				maxCommission:                 20,
 				epochLimitForUpdateCommission: 10,
@@ -238,13 +314,15 @@ func TestUtilsStruct_UpdateCommission(t *testing.T) {
 			wantErr: errors.New("error in fetching epoch"),
 		},
 		{
-			name: "Test 10: When update commission fails",
+			name: "Test 6: When update commission fails",
 			args: args{
-				config:                        config,
-				password:                      "test",
-				address:                       "0x000000000000000000000000000000000000dea1",
-				commission:                    10,
-				stakerId:                      1,
+				input: types.UpdateCommissionInput{
+					StakerId:   1,
+					Address:    "0x000000000000000000000000000000000000dea1",
+					Password:   "test",
+					Commission: 10,
+					Config:     config,
+				},
 				stakerInfo:                    bindings.StructsStaker{},
 				maxCommission:                 20,
 				epochLimitForUpdateCommission: 10,
@@ -256,13 +334,15 @@ func TestUtilsStruct_UpdateCommission(t *testing.T) {
 			wantErr: errors.New("error in updating commission"),
 		},
 		{
-			name: "Test 11: When commission is 0",
+			name: "Test 7: When commission is 0",
 			args: args{
-				config:                        config,
-				password:                      "test",
-				address:                       "0x000000000000000000000000000000000000dea1",
-				commission:                    0,
-				stakerId:                      1,
+				input: types.UpdateCommissionInput{
+					StakerId:   1,
+					Address:    "0x000000000000000000000000000000000000dea1",
+					Password:   "test",
+					Commission: 0,
+					Config:     config,
+				},
 				stakerInfo:                    bindings.StructsStaker{},
 				maxCommission:                 20,
 				epochLimitForUpdateCommission: 10,
@@ -274,13 +354,15 @@ func TestUtilsStruct_UpdateCommission(t *testing.T) {
 			wantErr: errors.New("commission out of range"),
 		},
 		{
-			name: "Test 12: When commission is greater than max commission",
+			name: "Test 8: When commission is greater than max commission",
 			args: args{
-				config:                        config,
-				password:                      "test",
-				address:                       "0x000000000000000000000000000000000000dea1",
-				commission:                    30,
-				stakerId:                      1,
+				input: types.UpdateCommissionInput{
+					StakerId:   1,
+					Address:    "0x000000000000000000000000000000000000dea1",
+					Password:   "test",
+					Commission: 30,
+					Config:     config,
+				},
 				stakerInfo:                    bindings.StructsStaker{},
 				maxCommission:                 20,
 				epochLimitForUpdateCommission: 10,
@@ -292,13 +374,15 @@ func TestUtilsStruct_UpdateCommission(t *testing.T) {
 			wantErr: errors.New("commission out of range"),
 		},
 		{
-			name: "Test 13: When the epoch is invalid for update",
+			name: "Test 9: When the epoch is invalid for update",
 			args: args{
-				config:     config,
-				password:   "test",
-				address:    "0x000000000000000000000000000000000000dea1",
-				commission: 10,
-				stakerId:   1,
+				input: types.UpdateCommissionInput{
+					StakerId:   1,
+					Address:    "0x000000000000000000000000000000000000dea1",
+					Password:   "test",
+					Commission: 10,
+					Config:     config,
+				},
 				stakerInfo: bindings.StructsStaker{
 					EpochCommissionLastUpdated: 1,
 				},
@@ -314,24 +398,8 @@ func TestUtilsStruct_UpdateCommission(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			GetTxnOptsMock = func(types.TransactionOptions) *bind.TransactOpts {
 				return txnOpts
-			}
-			GetConfigDataMock = func(UtilsStruct) (types.Configurations, error) {
-				return tt.args.config, tt.args.configErr
-			}
-			AssignPasswordMock = func(set *pflag.FlagSet) string {
-				return tt.args.password
-			}
-			GetStringAddressMock = func(*pflag.FlagSet) (string, error) {
-				return tt.args.address, tt.args.addressErr
-			}
-			GetUint8CommissionMock = func(*pflag.FlagSet) (uint8, error) {
-				return tt.args.commission, tt.args.commissionErr
-			}
-			GetStakerIdMock = func(*ethclient.Client, string) (uint32, error) {
-				return tt.args.stakerId, tt.args.stakerIdErr
 			}
 			GetStakerMock = func(*ethclient.Client, string, uint32) (bindings.StructsStaker, error) {
 				return tt.args.stakerInfo, tt.args.stakerInfoErr
@@ -348,16 +416,13 @@ func TestUtilsStruct_UpdateCommission(t *testing.T) {
 			UpdateCommissionMock = func(*ethclient.Client, *bind.TransactOpts, uint8) (*Types.Transaction, error) {
 				return tt.args.UpdateCommissionTxn, tt.args.UpdateCommissionErr
 			}
-			ConnectToClientMock = func(string2 string) *ethclient.Client {
-				return client
-			}
 			HashMock = func(*Types.Transaction) common.Hash {
 				return tt.args.hash
 			}
 			WaitForBlockCompletionMock = func(*ethclient.Client, string) int {
 				return tt.args.WaitForBlockCompletionStatus
 			}
-			gotErr := utilsStruct.UpdateCommission(flagSet)
+			gotErr := ExecuteUpdateCommission(tt.args.client, tt.args.input, utilsStruct)
 			if gotErr == nil || tt.wantErr == nil {
 				if gotErr != tt.wantErr {
 					t.Errorf("Error for UpdateCommission function, got = %v, want = %v", gotErr, tt.wantErr)

--- a/core/types/inputs.go
+++ b/core/types/inputs.go
@@ -14,3 +14,11 @@ type RedeemBountyInput struct {
 	Password string
 	BountyId uint32
 }
+
+type UpdateCommissionInput struct {
+	StakerId   uint32
+	Address    string
+	Password   string
+	Commission uint8
+	Config     Configurations
+}


### PR DESCRIPTION
# Description

Now `setDelegation` can be used both to set delegation status as well as update commission.

Fixes #493 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested on local hardhat
- [x] Tested with all the test cases

**Test Configuration**:
* Contracts version: v0.2.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules