### PR TITLE
Gas price fall back implemented

### DIFF
--- a/utils/options.go
+++ b/utils/options.go
@@ -65,12 +65,17 @@ func (*UtilsStruct) GetGasPrice(client *ethclient.Client, config types.Configura
 	var gas *big.Int
 	if config.GasPrice != 0 {
 		gas = big.NewInt(1).Mul(big.NewInt(int64(config.GasPrice)), big.NewInt(1e9))
-	} else {
-		var err error
-		gas, err = UtilsInterface.SuggestGasPriceWithRetry(client)
-		if err != nil {
-			log.Fatal(err)
-		}
+	}
+	var err error
+	suggestedGasPrice, err := UtilsInterface.SuggestGasPriceWithRetry(client)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Debugf("Suggested gas price: %d", suggestedGasPrice)
+	log.Debugf("Gas Price set in config: %d", gas)
+	if suggestedGasPrice.Cmp(gas) > 0 {
+		log.Debugf("Going with suggested gas price!")
+		gas = suggestedGasPrice
 	}
 	gasPrice := UtilsInterface.MultiplyFloatAndBigInt(gas, float64(config.GasMultiplier))
 	return gasPrice

--- a/utils/options.go
+++ b/utils/options.go
@@ -65,11 +65,14 @@ func (*UtilsStruct) GetGasPrice(client *ethclient.Client, config types.Configura
 	var gas *big.Int
 	if config.GasPrice != 0 {
 		gas = big.NewInt(1).Mul(big.NewInt(int64(config.GasPrice)), big.NewInt(1e9))
+	} else {
+		gas = big.NewInt(0)
 	}
 	var err error
 	suggestedGasPrice, err := UtilsInterface.SuggestGasPriceWithRetry(client)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		return UtilsInterface.MultiplyFloatAndBigInt(gas, float64(config.GasMultiplier))
 	}
 	log.Debugf("Suggested gas price: %d", suggestedGasPrice)
 	log.Debugf("Gas Price set in config: %d", gas)


### PR DESCRIPTION
# Description

Due to low gas price, go-ethereum used to throw an error : `err: max fee per gas less than block base fee`. To avoid this, now we use suggest gas price, if the gas price mentioned in the config is not greater.

Fixes #549 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested on local hardhat.
- [x] Tested with all the test cases.

**Test Configuration**:
* Contracts version: `0.2.0-patch2`
* Hardware: `Macbook M1 Air`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules