### PR TITLE
Add Error Message and codes for addStake and claimBounty.

### DIFF
--- a/cmd/addStake.go
+++ b/cmd/addStake.go
@@ -31,18 +31,18 @@ func initialiseStake(cmd *cobra.Command, args []string) {
 
 func (*UtilsStruct) ExecuteStake(flagSet *pflag.FlagSet) {
 	config, err := cmdUtils.GetConfigData()
-	utils.CheckError("Error in getting config: ", err)
+	utils.CheckError(GetError(ConfigErrorCode, ConfigErrorMessage), err)
 
 	password := razorUtils.AssignPassword(flagSet)
 	address, err := flagSetUtils.GetStringAddress(flagSet)
-	utils.CheckError("Error in getting address: ", err)
+	utils.CheckError(GetError(AddressErrorCode, AddressErrorMessage), err)
 
 	client := razorUtils.ConnectToClient(config.Provider)
 	balance, err := razorUtils.FetchBalance(client, address)
-	utils.CheckError("Error in fetching balance for account: "+address, err)
+	utils.CheckError(GetError(FetchBalanceErrorCode, FetchBalanceErrorMessage), err)
 
 	valueInWei, err := cmdUtils.AssignAmountInWei(flagSet)
-	utils.CheckError("Error in getting amount: ", err)
+	utils.CheckError(GetError(AmountErrorCode, AmountErrorMessage), err)
 
 	razorUtils.CheckAmountAndBalance(valueInWei, balance)
 
@@ -58,28 +58,28 @@ func (*UtilsStruct) ExecuteStake(flagSet *pflag.FlagSet) {
 	}
 
 	approveTxnHash, err := cmdUtils.Approve(txnArgs)
-	utils.CheckError("Approve error: ", err)
+	utils.CheckError(GetError(ApproveErrorCode, ApproveErrorMessage), err)
 
 	if approveTxnHash != core.NilHash {
 		razorUtils.WaitForBlockCompletion(txnArgs.Client, approveTxnHash.String())
 	}
 
 	stakeTxnHash, err := cmdUtils.StakeCoins(txnArgs)
-	utils.CheckError("Stake error: ", err)
+	utils.CheckError(GetError(StakeErrorCode, StakeErrorMessage), err)
 	razorUtils.WaitForBlockCompletion(txnArgs.Client, stakeTxnHash.String())
 
 	if razorUtils.IsFlagPassed("autoVote") {
 		isAutoVote, err := flagSetUtils.GetBoolAutoVote(flagSet)
-		utils.CheckError("Error in getting autoVote status: ", err)
+		utils.CheckError(GetError(AutoVoteStatusErrorCode, AutoVoteStatusErrorMessage), err)
 
 		if isAutoVote {
 			log.Info("Staked!...Starting to vote now.")
 			account := types.Account{Address: address, Password: password}
 			isRogue, err := flagSetUtils.GetBoolRogue(flagSet)
-			utils.CheckError("Error in getting rogue status: ", err)
+			utils.CheckError(GetError(RogueStatusErrorCode, RogueStatusErrorMessage), err)
 
 			rogueMode, err := flagSetUtils.GetStringSliceRogueMode(flagSet)
-			utils.CheckError("Error in getting rogue modes: ", err)
+			utils.CheckError(GetError(RogueModeErrorCode, RogueModeErrorMessage), err)
 
 			rogueData := types.Rogue{
 				IsRogue:   isRogue,

--- a/cmd/claimBounty.go
+++ b/cmd/claimBounty.go
@@ -31,14 +31,14 @@ func initialiseClaimBounty(cmd *cobra.Command, args []string) {
 
 func (*UtilsStruct) ExecuteClaimBounty(flagSet *pflag.FlagSet) {
 	config, err := cmdUtils.GetConfigData()
-	utils.CheckError("Error in getting config: ", err)
+	utils.CheckError(GetError(ConfigErrorCode, ConfigErrorMessage), err)
 
 	password := razorUtils.AssignPassword(flagSet)
 	address, err := flagSetUtils.GetStringAddress(flagSet)
-	utils.CheckError("Error in getting address: ", err)
+	utils.CheckError(GetError(AddressErrorCode, AddressErrorMessage), err)
 
 	bountyId, err := flagSetUtils.GetUint32BountyId(flagSet)
-	utils.CheckError("Error in getting bountyId: ", err)
+	utils.CheckError(GetError(BountyIdErrorCode, BountyIdErrorMessage), err)
 
 	client := razorUtils.ConnectToClient(config.Provider)
 
@@ -49,7 +49,7 @@ func (*UtilsStruct) ExecuteClaimBounty(flagSet *pflag.FlagSet) {
 	}
 
 	txn, err := cmdUtils.ClaimBounty(config, client, redeemBountyInput)
-	utils.CheckError("ClaimBounty error: ", err)
+	utils.CheckError(GetError(ClaimBountyErrorCode, ClaimBountyErrorMessage), err)
 
 	if txn != core.NilHash {
 		razorUtils.WaitForBlockCompletion(client, txn.String())
@@ -70,7 +70,7 @@ func (*UtilsStruct) ClaimBounty(config types.Configurations, client *ethclient.C
 	}
 	epoch, err := razorUtils.GetEpoch(txnArgs.Client)
 	if err != nil {
-		log.Error("Error in getting epoch: ", err)
+		log.Error(GetError(FetchEpochErrorCode, FetchEpochErrorMessage), err)
 		return common.Hash{0x00}, err
 	}
 

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,0 +1,39 @@
+package cmd
+
+import "fmt"
+
+//Flag error codes
+const ConfigErrorCode = 1001
+const AddressErrorCode = 1002
+const FetchBalanceErrorCode = 1003
+const AmountErrorCode = 1004
+const RogueStatusErrorCode = 1007
+const RogueModeErrorCode = 1008
+const AutoVoteStatusErrorCode = 1009
+const BountyIdErrorCode = 1010
+
+//Functionality error codes
+const ApproveErrorCode = 1020
+const StakeErrorCode = 1021
+const ClaimBountyErrorCode = 1022
+const FetchEpochErrorCode = 1023
+
+//Flag error messages
+const ConfigErrorMessage = "Error in getting config:"
+const AddressErrorMessage = "Error in fetching address:"
+const FetchBalanceErrorMessage = "Error in fetching balance for account:"
+const AmountErrorMessage = "Error in getting amount:"
+const RogueStatusErrorMessage = "Error in getting rogue status:"
+const RogueModeErrorMessage = "Error in getting rogue mode:"
+const AutoVoteStatusErrorMessage = "Error in getting autoVote status:"
+const BountyIdErrorMessage = "Error in getting bountyId:"
+
+//Functionality error messages
+const ApproveErrorMessage = "Approve error:"
+const StakeErrorMessage = "Stake error:"
+const ClaimBountyErrorMessage = "ClaimBounty error:"
+const FetchEpochErrorMessage = "Error in getting epoch:"
+
+var GetError = func(errCode int, errMessage string) string {
+	return fmt.Sprintf("ERR: %d\t%s ", errCode, errMessage)
+}


### PR DESCRIPTION
# Description

The error codes and messages are consolidated in the errors.go file now.
The `GetError` function is now used to get the error message and code.


Fixes #40 

## Type of change

- [ ] Code cleanup
