### PR TITLE
added a method to calculate block number at beginning of epoch

### DIFF
--- a/utils/common.go
+++ b/utils/common.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	solsha3 "github.com/miguelmota/go-solidity-sha3"
 	"math/big"
 	"os"
 	"razor/core"
@@ -209,16 +208,25 @@ func (*UtilsStruct) CalculateBlockTime(client *ethclient.Client) int64 {
 	}
 	return int64(latestBlock.Time - lastSecondBlock.Time)
 }
+func CalculateBlockNumberAtEpochBeginning(client *ethclient.Client, epochLength uint64, currentBlockNumber uint64) uint64 {
+	block, err := ClientInterface.HeaderByNumber(client, context.Background(), big.NewInt(int64(currentBlockNumber)))
+	if err != nil {
+		log.Fatalf("Error in fetching block : %s", err)
+	}
+	current_epoch := block.Time / uint64(core.EpochLength)
+	previousBlockNumber := block.Time - uint64(core.EpochLength)
 
-func (*UtilsStruct) CalculateSalt(epoch uint32, medians []uint32) [32]byte {
-	salt := solsha3.SoliditySHA3([]string{"uint32", "[]uint32"}, []interface{}{epoch, medians})
-	var saltInBytes32 [32]byte
-	copy(saltInBytes32[:], salt)
-	return saltInBytes32
-}
+	previousBlock, err := ClientInterface.HeaderByNumber(client, context.Background(), big.NewInt(int64(previousBlockNumber)))
+	if err != nil {
+		log.Fatalf("Err in fetching Previous block : %s", err)
+	}
+	previousBlockActualTimestamp := previousBlock.Time
+	previousBlockAssumedTimestamp := block.Time - uint64(core.EpochLength)
+	previous_epoch := previousBlockActualTimestamp / uint64(core.EpochLength)
+	if previousBlockActualTimestamp > previousBlockAssumedTimestamp && previous_epoch != current_epoch-1 {
+		return CalculateBlockNumberAtEpochBeginning(client, uint64(core.EpochLength), previousBlockNumber)
 
-func (*UtilsStruct) Prng(max uint32, prngHashes []byte) *big.Int {
-	sum := big.NewInt(0).SetBytes(prngHashes)
-	maxBigInt := big.NewInt(int64(max))
-	return sum.Mod(sum, maxBigInt)
+	}
+	return previousBlockNumber
+
 }


### PR DESCRIPTION
# Description

since on sKale timestamp is not fixed we cannot calculate block time average.

Fixes #610 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Contracts version:
* Hardware:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules