### PR TITLE
Changed value of flag for medians dispute case

### DIFF
--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -315,7 +315,7 @@ func (*UtilsStruct) MakeBlock(client *ethclient.Client, blockNumber *big.Int, ep
 		influenceSum := revealedDataMaps.InfluenceSum[leafId]
 		if influenceSum != nil && influenceSum.Cmp(big.NewInt(0)) != 0 {
 			idsRevealedInThisEpoch = append(idsRevealedInThisEpoch, activeCollections[leafId])
-			if rogueData.IsRogue && utils.Contains(rogueData.RogueMode, "propose") {
+			if rogueData.IsRogue && utils.Contains(rogueData.RogueMode, "medians") {
 				medians = append(medians, rand.Uint32())
 				continue
 			}


### PR DESCRIPTION
# Description

Medians dispute will occur when `medians` is provided as a value to `--rogueMode` flag  instead of `propose` as a value to flag.

Fixes #664

