### PR TITLE
Missing ids dispute fix

### DIFF
--- a/cmd/dispute.go
+++ b/cmd/dispute.go
@@ -206,6 +206,12 @@ func (*UtilsStruct) CheckDisputeForIds(client *ethclient.Client, transactionOpts
 		transactionOpts.MethodName = "disputeCollectionIdShouldBePresent"
 		transactionOpts.Parameters = []interface{}{epoch, blockIndex, missingCollectionId}
 		txnOpts := razorUtils.GetTxnOpts(transactionOpts)
+		gasLimit := txnOpts.GasLimit
+		incrementedGasLimit, err := utilsInterface.IncreaseGasLimitValue(client, gasLimit, 5.5)
+		if err != nil {
+			return nil, err
+		}
+		txnOpts.GasLimit = incrementedGasLimit
 		log.Debug("Disputing collection id should be present!")
 		log.Debugf("Epoch: %d, blockIndex: %d, missingCollectionId: %d", epoch, blockIndex, missingCollectionId)
 		return blockManagerUtils.DisputeCollectionIdShouldBePresent(client, txnOpts, epoch, blockIndex, missingCollectionId)

--- a/cmd/dispute_test.go
+++ b/cmd/dispute_test.go
@@ -771,6 +771,7 @@ func TestCheckDisputeForIds(t *testing.T) {
 			utils.UtilsInterface = utilsPkgMock
 			razorUtils = utilsMock
 			blockManagerUtils = blockManagerUtilsMock
+			utilsInterface = utilsPkgMock
 
 			utilsPkgMock.On("IsSorted", mock.Anything).Return(tt.args.isSorted, tt.args.index0, tt.args.index1)
 			utilsMock.On("GetTxnOpts", mock.AnythingOfType("types.TransactionOptions")).Return(txnOpts)
@@ -779,6 +780,7 @@ func TestCheckDisputeForIds(t *testing.T) {
 			blockManagerUtilsMock.On("DisputeCollectionIdShouldBePresent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.DisputeCollectionIdShouldBePresent, tt.args.DisputeCollectionIdShouldBePresentErr)
 			utilsPkgMock.On("IsMissing", mock.Anything, mock.Anything).Return(tt.args.isPresent, tt.args.positionOfPresentValue, tt.args.presentCollectionId)
 			blockManagerUtilsMock.On("DisputeCollectionIdShouldBeAbsent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.DisputeCollectionIdShouldBeAbsent, tt.args.DisputeCollectionIdShouldBeAbsentErr)
+			utilsPkgMock.On("IncreaseGasLimitValue", mock.Anything, mock.Anything, mock.Anything).Return(uint64(2000), nil)
 			ut := &UtilsStruct{}
 			got, err := ut.CheckDisputeForIds(client, transactionOpts, epoch, blockIndex, tt.args.idsInProposedBlock, tt.args.revealedCollectionIds)
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
# Description

Increased gasLimit for `disputeCollectionIdShouldBePresent`

Fixes #668
