### PR TITLE
Medians and votes converted from uint32 to *big.Int

### DIFF
--- a/cmd/dispute.go
+++ b/cmd/dispute.go
@@ -109,7 +109,7 @@ func (*UtilsStruct) HandleDispute(client *ethclient.Client, config types.Configu
 		}
 
 		// Median Value dispute
-		isEqual, mismatchIndex := utils.IsEqualUint32(proposedBlock.Medians, medians)
+		isEqual, mismatchIndex := utils.IsEqual(proposedBlock.Medians, medians)
 		if !isEqual {
 			log.Warn("BLOCK NOT MATCHING WITH LOCAL CALCULATIONS.")
 			log.Debug("Block Values: ", proposedBlock.Medians)
@@ -148,7 +148,7 @@ func (*UtilsStruct) HandleDispute(client *ethclient.Client, config types.Configu
 	return nil
 }
 
-func (*UtilsStruct) GetLocalMediansData(client *ethclient.Client, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) ([]uint32, []uint16, *types.RevealedDataMaps, error) {
+func (*UtilsStruct) GetLocalMediansData(client *ethclient.Client, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) ([]*big.Int, []uint16, *types.RevealedDataMaps, error) {
 
 	if _mediansData == nil && !rogueData.IsRogue {
 		fileName, err := razorUtils.GetProposeDataFileName(account.Address)
@@ -181,10 +181,9 @@ CalculateMedian:
 		_revealedDataMaps = revealedDataMaps
 	}
 
-	mediansInUint32 := razorUtils.ConvertBigIntArrayToUint32Array(_mediansData)
 	log.Debug("Locally calculated data:")
-	log.Debugf("Medians: %d", mediansInUint32)
-	return mediansInUint32, _revealedCollectionIds, _revealedDataMaps, nil
+	log.Debugf("Medians: %d", _mediansData)
+	return _mediansData, _revealedCollectionIds, _revealedDataMaps, nil
 }
 
 func (*UtilsStruct) CheckDisputeForIds(client *ethclient.Client, transactionOpts types.TransactionOptions, epoch uint32, blockIndex uint8, idsInProposedBlock []uint16, revealedCollectionIds []uint16) (*types2.Transaction, error) {

--- a/cmd/dispute.go
+++ b/cmd/dispute.go
@@ -176,7 +176,7 @@ CalculateMedian:
 			log.Error("Error in calculating block medians")
 			return nil, nil, nil, err
 		}
-		_mediansData = razorUtils.ConvertUint32ArrayToBigIntArray(medians)
+		_mediansData = medians
 		_revealedCollectionIds = revealedCollectionIds
 		_revealedDataMaps = revealedDataMaps
 	}
@@ -249,7 +249,7 @@ func (*UtilsStruct) CheckDisputeForIds(client *ethclient.Client, transactionOpts
 	return nil, nil
 }
 
-func (*UtilsStruct) Dispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockIndex uint8, proposedBlock bindings.StructsBlock, leafId uint16, sortedValues []uint32) error {
+func (*UtilsStruct) Dispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockIndex uint8, proposedBlock bindings.StructsBlock, leafId uint16, sortedValues []*big.Int) error {
 	blockManager := razorUtils.GetBlockManager(client)
 
 	txnOpts := razorUtils.GetTxnOpts(types.TransactionOptions{
@@ -285,7 +285,7 @@ func (*UtilsStruct) Dispute(client *ethclient.Client, config types.Configuration
 	return nil
 }
 
-func GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, leafId uint16, sortedValues []uint32) {
+func GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, leafId uint16, sortedValues []*big.Int) {
 	if len(sortedValues) == 0 {
 		return
 	}

--- a/cmd/dispute_test.go
+++ b/cmd/dispute_test.go
@@ -982,7 +982,7 @@ func BenchmarkHandleDispute(b *testing.B) {
 
 				utils.UtilsInterface = utilsPkgMock
 
-				medians := []uint32{6901548, 498307}
+				medians := []*big.Int{big.NewInt(6901548), big.NewInt(498307)}
 				revealedCollectionIds := []uint16{1}
 				revealedDataMaps := &types.RevealedDataMaps{
 					SortedRevealedValues: nil,

--- a/cmd/dispute_test.go
+++ b/cmd/dispute_test.go
@@ -34,7 +34,7 @@ func TestDispute(t *testing.T) {
 		blockIndex    uint8
 		proposedBlock bindings.StructsBlock
 		leafId        uint16
-		sortedValues  []uint32
+		sortedValues  []*big.Int
 		blockManager  *bindings.BlockManager
 	)
 
@@ -131,7 +131,7 @@ func TestHandleDispute(t *testing.T) {
 		biggestStake              *big.Int
 		biggestStakeId            uint32
 		biggestStakeErr           error
-		medians                   []uint32
+		medians                   []*big.Int
 		revealedCollectionIds     []uint16
 		revealedDataMaps          *types.RevealedDataMaps
 		mediansErr                error
@@ -160,7 +160,7 @@ func TestHandleDispute(t *testing.T) {
 				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
-				medians:                []uint32{6901548, 498307},
+				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
 				revealedCollectionIds:  []uint16{1},
 				revealedDataMaps: &types.RevealedDataMaps{
 					SortedRevealedValues: nil,
@@ -168,7 +168,7 @@ func TestHandleDispute(t *testing.T) {
 					InfluenceSum:         nil,
 				},
 				proposedBlock: bindings.StructsBlock{
-					Medians:      []uint32{6901548, 498307},
+					Medians:      []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
 					Valid:        true,
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				},
@@ -184,7 +184,7 @@ func TestHandleDispute(t *testing.T) {
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				proposedBlock: bindings.StructsBlock{
-					Medians:      []uint32{6701548, 478307},
+					Medians:      []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				},
 				isEqual:    true,
@@ -197,7 +197,7 @@ func TestHandleDispute(t *testing.T) {
 			args: args{
 				sortedProposedBlockIdsErr: errors.New("sortedProposedBlockIds error"),
 				proposedBlock: bindings.StructsBlock{
-					Medians: []uint32{6701548, 478307},
+					Medians: []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				},
 				isEqual:    true,
 				disputeErr: nil,
@@ -221,7 +221,7 @@ func TestHandleDispute(t *testing.T) {
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				proposedBlock: bindings.StructsBlock{
-					Medians:      []uint32{6701548, 478307},
+					Medians:      []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				},
 				isEqual: false,
@@ -235,7 +235,7 @@ func TestHandleDispute(t *testing.T) {
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				proposedBlock: bindings.StructsBlock{
-					Medians:      []uint32{6701548, 478307},
+					Medians:      []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 					Valid:        true,
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(4356), big.NewInt(1e18)),
 				},
@@ -253,7 +253,7 @@ func TestHandleDispute(t *testing.T) {
 				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
 				biggestStakeErr:        errors.New("biggestInfluenceAndIdErr"),
 				proposedBlock: bindings.StructsBlock{
-					Medians:      []uint32{6701548, 478307},
+					Medians:      []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 					Valid:        true,
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(4356), big.NewInt(1e18)),
 				},
@@ -272,7 +272,7 @@ func TestHandleDispute(t *testing.T) {
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				proposedBlock: bindings.StructsBlock{
-					Medians:      []uint32{6701548, 478307},
+					Medians:      []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 					Valid:        true,
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(4356), big.NewInt(1e18)),
 				},
@@ -299,7 +299,7 @@ func TestHandleDispute(t *testing.T) {
 				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
-				medians:                []uint32{6901548, 498307},
+				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
 				revealedCollectionIds:  []uint16{1},
 				revealedDataMaps: &types.RevealedDataMaps{
 					SortedRevealedValues: nil,
@@ -307,7 +307,7 @@ func TestHandleDispute(t *testing.T) {
 					InfluenceSum:         nil,
 				},
 				proposedBlock: bindings.StructsBlock{
-					Medians:      []uint32{6901548, 498307},
+					Medians:      []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
 					Valid:        true,
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				},
@@ -323,7 +323,7 @@ func TestHandleDispute(t *testing.T) {
 				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
-				medians:                []uint32{6901548, 498307},
+				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
 				revealedCollectionIds:  []uint16{1},
 				revealedDataMaps: &types.RevealedDataMaps{
 					SortedRevealedValues: nil,
@@ -331,7 +331,7 @@ func TestHandleDispute(t *testing.T) {
 					InfluenceSum:         nil,
 				},
 				proposedBlock: bindings.StructsBlock{
-					Medians:      []uint32{6901548, 498307},
+					Medians:      []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
 					Valid:        true,
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				},
@@ -348,7 +348,7 @@ func TestHandleDispute(t *testing.T) {
 				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
-				medians:                []uint32{69015, 498307},
+				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
 				revealedCollectionIds:  []uint16{1},
 				revealedDataMaps: &types.RevealedDataMaps{
 					SortedRevealedValues: nil,
@@ -357,7 +357,7 @@ func TestHandleDispute(t *testing.T) {
 				},
 				proposedBlock: bindings.StructsBlock{
 					Ids:          []uint16{1, 2},
-					Medians:      []uint32{6901548, 498307},
+					Medians:      []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
 					Valid:        true,
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				},
@@ -374,7 +374,7 @@ func TestHandleDispute(t *testing.T) {
 				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
-				medians:                []uint32{69015, 498307},
+				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
 				revealedCollectionIds:  []uint16{1},
 				revealedDataMaps: &types.RevealedDataMaps{
 					SortedRevealedValues: nil,
@@ -383,7 +383,7 @@ func TestHandleDispute(t *testing.T) {
 				},
 				proposedBlock: bindings.StructsBlock{
 					Ids:          []uint16{1, 2},
-					Medians:      []uint32{6901548, 498307},
+					Medians:      []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
 					Valid:        true,
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				},
@@ -447,7 +447,7 @@ func TestGiveSorted(t *testing.T) {
 	var epoch uint32
 	var assetId uint16
 	type args struct {
-		sortedStakers []uint32
+		sortedValues  []*big.Int
 		giveSorted    *Types.Transaction
 		giveSortedErr error
 		hash          common.Hash
@@ -459,28 +459,28 @@ func TestGiveSorted(t *testing.T) {
 		{
 			name: "Test 1: When Give Sorted executes successfully",
 			args: args{
-				sortedStakers: []uint32{2, 1, 3, 5},
-				giveSorted:    &Types.Transaction{},
-				hash:          common.BigToHash(big.NewInt(1)),
+				sortedValues: []*big.Int{big.NewInt(2), big.NewInt(1), big.NewInt(3), big.NewInt(5)},
+				giveSorted:   &Types.Transaction{},
+				hash:         common.BigToHash(big.NewInt(1)),
 			},
 		},
 		{
 			name: "Test 2: When there is an error from GiveSorted",
 			args: args{
-				sortedStakers: []uint32{2, 1, 3, 5},
+				sortedValues:  []*big.Int{big.NewInt(2), big.NewInt(1), big.NewInt(3), big.NewInt(5)},
 				giveSortedErr: errors.New("giveSorted error"),
 			},
 		},
 		{
 			name: "Test 3: When sortedStakers is nil",
 			args: args{
-				sortedStakers: nil,
+				sortedValues: nil,
 			},
 		},
 		{
 			name: "Test 4: When error is gas limit reached",
 			args: args{
-				sortedStakers: []uint32{2, 1, 3, 5},
+				sortedValues:  []*big.Int{big.NewInt(2), big.NewInt(1), big.NewInt(3), big.NewInt(5)},
 				giveSortedErr: errors.New("gas limit reached"),
 				giveSorted:    &Types.Transaction{},
 				hash:          common.BigToHash(big.NewInt(1)),
@@ -489,7 +489,7 @@ func TestGiveSorted(t *testing.T) {
 		{
 			name: "Test 5: When error is gas limit reached with higher number of stakers",
 			args: args{
-				sortedStakers: []uint32{2, 1, 3, 5, 7, 8, 9, 10, 6, 11, 13, 12, 14, 15, 4, 20, 19, 18, 17, 16},
+				sortedValues:  []*big.Int{big.NewInt(2), big.NewInt(1), big.NewInt(3), big.NewInt(5), big.NewInt(7), big.NewInt(8), big.NewInt(9), big.NewInt(10), big.NewInt(6), big.NewInt(11), big.NewInt(13), big.NewInt(12), big.NewInt(14), big.NewInt(15), big.NewInt(4), big.NewInt(20), big.NewInt(19), big.NewInt(18), big.NewInt(17), big.NewInt(16)},
 				giveSortedErr: errors.New("gas limit reached"),
 				giveSorted:    &Types.Transaction{},
 				hash:          common.BigToHash(big.NewInt(1)),
@@ -511,7 +511,7 @@ func TestGiveSorted(t *testing.T) {
 			utilsMock.On("WaitForBlockCompletion", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string")).Return(1)
 			blockManagerUtilsMock.On("GiveSorted", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.giveSorted, nil)
 
-			GiveSorted(client, blockManager, txnOpts, epoch, assetId, tt.args.sortedStakers)
+			GiveSorted(client, blockManager, txnOpts, epoch, assetId, tt.args.sortedValues)
 		})
 	}
 }
@@ -529,17 +529,15 @@ func TestGetLocalMediansData(t *testing.T) {
 		fileNameErr           error
 		proposedData          types.ProposeFileData
 		proposeDataErr        error
-		medians               []uint32
+		medians               []*big.Int
 		revealedCollectionIds []uint16
 		revealedDataMaps      *types.RevealedDataMaps
 		mediansErr            error
-		mediansBigInt         []*big.Int
-		mediansInUint32       []uint32
 	}
 	tests := []struct {
 		name    string
 		args    args
-		want    []uint32
+		want    []*big.Int
 		want1   []uint16
 		want2   *types.RevealedDataMaps
 		wantErr bool
@@ -590,13 +588,11 @@ func TestGetLocalMediansData(t *testing.T) {
 		{
 			name: "Test 5: When GetLocalMediansData executes successfully",
 			args: args{
-				medians:               []uint32{100, 200, 300},
+				medians:               []*big.Int{big.NewInt(100), big.NewInt(200), big.NewInt(300)},
 				revealedCollectionIds: []uint16{1, 2, 3},
 				revealedDataMaps:      &types.RevealedDataMaps{},
-				mediansBigInt:         []*big.Int{big.NewInt(100), big.NewInt(200), big.NewInt(300)},
-				mediansInUint32:       []uint32{100, 200, 300},
 			},
-			want:    []uint32{100, 200, 300},
+			want:    []*big.Int{big.NewInt(100), big.NewInt(200), big.NewInt(300)},
 			want1:   []uint16{1, 2, 3},
 			want2:   &types.RevealedDataMaps{},
 			wantErr: false,
@@ -613,8 +609,6 @@ func TestGetLocalMediansData(t *testing.T) {
 			utilsMock.On("GetProposeDataFileName", mock.AnythingOfType("string")).Return(tt.args.fileName, tt.args.fileNameErr)
 			utilsMock.On("ReadFromProposeJsonFile", mock.Anything).Return(tt.args.proposedData, tt.args.proposeDataErr)
 			cmdUtilsMock.On("MakeBlock", mock.AnythingOfType("*ethclient.Client"), mock.Anything, mock.Anything, mock.Anything).Return(tt.args.medians, tt.args.revealedCollectionIds, tt.args.revealedDataMaps, tt.args.mediansErr)
-			utilsMock.On("ConvertUint32ArrayToBigIntArray", mock.Anything).Return(tt.args.mediansBigInt)
-			utilsMock.On("ConvertBigIntArrayToUint32Array", mock.Anything).Return(tt.args.mediansInUint32)
 			ut := &UtilsStruct{}
 			got, got1, got2, err := ut.GetLocalMediansData(client, account, tt.args.epoch, blockNumber, rogueData)
 			if (err != nil) != tt.wantErr {
@@ -995,7 +989,7 @@ func BenchmarkHandleDispute(b *testing.B) {
 					VoteWeights:          nil,
 					InfluenceSum:         nil}
 				proposedBlock := bindings.StructsBlock{
-					Medians:      []uint32{6901548, 498307},
+					Medians:      []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
 					Valid:        true,
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18))}
 

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -101,7 +101,6 @@ type UtilsInterface interface {
 	GetEpochLastRevealed(client *ethclient.Client, stakerId uint32) (uint32, error)
 	GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (*big.Int, error)
 	GetTotalInfluenceRevealed(client *ethclient.Client, epoch uint32, medianIndex uint16) (*big.Int, error)
-	ConvertBigIntArrayToUint32Array(bigIntArray []*big.Int) []uint32
 	GetActiveCollections(client *ethclient.Client) ([]uint16, error)
 	GetBlockManager(client *ethclient.Client) *bindings.BlockManager
 	GetSortedProposedBlockIds(client *ethclient.Client, epoch uint32) ([]uint32, error)
@@ -286,7 +285,7 @@ type UtilsCmdInterface interface {
 	GetIteration(client *ethclient.Client, proposer types.ElectedProposer, bufferPercent int32) int
 	Propose(client *ethclient.Client, config types.Configurations, account types.Account, staker bindings.StructsStaker, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) (common.Hash, error)
 	GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []*big.Int)
-	GetLocalMediansData(client *ethclient.Client, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) ([]uint32, []uint16, *types.RevealedDataMaps, error)
+	GetLocalMediansData(client *ethclient.Client, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) ([]*big.Int, []uint16, *types.RevealedDataMaps, error)
 	CheckDisputeForIds(client *ethclient.Client, transactionOpts types.TransactionOptions, epoch uint32, blockIndex uint8, idsInProposedBlock []uint16, revealedCollectionIds []uint16) (*Types.Transaction, error)
 	Dispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockIndex uint8, proposedBlock bindings.StructsBlock, leafId uint16, sortedValues []*big.Int) error
 	GetCollectionIdPositionInBlock(client *ethclient.Client, leafId uint16, proposedBlock bindings.StructsBlock) *big.Int

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -99,7 +99,7 @@ type UtilsInterface interface {
 	GetMaxAltBlocks(client *ethclient.Client) (uint8, error)
 	GetProposedBlock(client *ethclient.Client, epoch uint32, proposedBlockId uint32) (bindings.StructsBlock, error)
 	GetEpochLastRevealed(client *ethclient.Client, stakerId uint32) (uint32, error)
-	GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (uint32, error)
+	GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (*big.Int, error)
 	GetTotalInfluenceRevealed(client *ethclient.Client, epoch uint32, medianIndex uint16) (*big.Int, error)
 	ConvertBigIntArrayToUint32Array(bigIntArray []*big.Int) []uint32
 	GetActiveCollections(client *ethclient.Client) ([]uint16, error)
@@ -155,13 +155,13 @@ type KeystoreInterface interface {
 
 type BlockManagerInterface interface {
 	ClaimBlockReward(client *ethclient.Client, opts *bind.TransactOpts) (*Types.Transaction, error)
-	Propose(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, ids []uint16, medians []uint32, iteration *big.Int, biggestInfluencerId uint32) (*Types.Transaction, error)
+	Propose(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, ids []uint16, medians []*big.Int, iteration *big.Int, biggestInfluencerId uint32) (*Types.Transaction, error)
 	FinalizeDispute(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, blockIndex uint8, positionOfCollectionInBlock *big.Int) (*Types.Transaction, error)
 	DisputeBiggestStakeProposed(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, blockIndex uint8, correctBiggestStakerId uint32) (*Types.Transaction, error)
 	DisputeOnOrderOfIds(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, blockIndex uint8, index0 *big.Int, index1 *big.Int) (*Types.Transaction, error)
 	DisputeCollectionIdShouldBeAbsent(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, blockIndex uint8, id uint16, positionOfCollectionInBlock *big.Int) (*Types.Transaction, error)
 	DisputeCollectionIdShouldBePresent(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, blockIndex uint8, id uint16) (*Types.Transaction, error)
-	GiveSorted(blockManager *bindings.BlockManager, opts *bind.TransactOpts, epoch uint32, leafId uint16, sortedValues []uint32) (*Types.Transaction, error)
+	GiveSorted(blockManager *bindings.BlockManager, opts *bind.TransactOpts, epoch uint32, leafId uint16, sortedValues []*big.Int) (*Types.Transaction, error)
 }
 
 type VoteManagerInterface interface {
@@ -280,15 +280,15 @@ type UtilsCmdInterface interface {
 	ExecuteUpdateCollection(flagSet *pflag.FlagSet)
 	UpdateCollection(client *ethclient.Client, config types.Configurations, collectionInput types.CreateCollectionInput, collectionId uint16) (common.Hash, error)
 	InfluencedMedian(sortedVotes []*big.Int, totalInfluenceRevealed *big.Int) *big.Int
-	MakeBlock(client *ethclient.Client, blockNumber *big.Int, epoch uint32, rogueData types.Rogue) ([]uint32, []uint16, *types.RevealedDataMaps, error)
+	MakeBlock(client *ethclient.Client, blockNumber *big.Int, epoch uint32, rogueData types.Rogue) ([]*big.Int, []uint16, *types.RevealedDataMaps, error)
 	IsElectedProposer(proposer types.ElectedProposer, currentStakerStake *big.Int) bool
 	GetSortedRevealedValues(client *ethclient.Client, blockNumber *big.Int, epoch uint32) (*types.RevealedDataMaps, error)
 	GetIteration(client *ethclient.Client, proposer types.ElectedProposer, bufferPercent int32) int
 	Propose(client *ethclient.Client, config types.Configurations, account types.Account, staker bindings.StructsStaker, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) (common.Hash, error)
-	GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []uint32)
+	GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []*big.Int)
 	GetLocalMediansData(client *ethclient.Client, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) ([]uint32, []uint16, *types.RevealedDataMaps, error)
 	CheckDisputeForIds(client *ethclient.Client, transactionOpts types.TransactionOptions, epoch uint32, blockIndex uint8, idsInProposedBlock []uint16, revealedCollectionIds []uint16) (*Types.Transaction, error)
-	Dispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockIndex uint8, proposedBlock bindings.StructsBlock, leafId uint16, sortedValues []uint32) error
+	Dispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockIndex uint8, proposedBlock bindings.StructsBlock, leafId uint16, sortedValues []*big.Int) error
 	GetCollectionIdPositionInBlock(client *ethclient.Client, leafId uint16, proposedBlock bindings.StructsBlock) *big.Int
 	HandleDispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) error
 	ExecuteExtendLock(flagSet *pflag.FlagSet)

--- a/cmd/mocks/block_manager_interface.go
+++ b/cmd/mocks/block_manager_interface.go
@@ -159,11 +159,11 @@ func (_m *BlockManagerInterface) FinalizeDispute(client *ethclient.Client, opts 
 }
 
 // GiveSorted provides a mock function with given fields: blockManager, opts, epoch, leafId, sortedValues
-func (_m *BlockManagerInterface) GiveSorted(blockManager *bindings.BlockManager, opts *bind.TransactOpts, epoch uint32, leafId uint16, sortedValues []uint32) (*types.Transaction, error) {
+func (_m *BlockManagerInterface) GiveSorted(blockManager *bindings.BlockManager, opts *bind.TransactOpts, epoch uint32, leafId uint16, sortedValues []*big.Int) (*types.Transaction, error) {
 	ret := _m.Called(blockManager, opts, epoch, leafId, sortedValues)
 
 	var r0 *types.Transaction
-	if rf, ok := ret.Get(0).(func(*bindings.BlockManager, *bind.TransactOpts, uint32, uint16, []uint32) *types.Transaction); ok {
+	if rf, ok := ret.Get(0).(func(*bindings.BlockManager, *bind.TransactOpts, uint32, uint16, []*big.Int) *types.Transaction); ok {
 		r0 = rf(blockManager, opts, epoch, leafId, sortedValues)
 	} else {
 		if ret.Get(0) != nil {
@@ -172,7 +172,7 @@ func (_m *BlockManagerInterface) GiveSorted(blockManager *bindings.BlockManager,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*bindings.BlockManager, *bind.TransactOpts, uint32, uint16, []uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(*bindings.BlockManager, *bind.TransactOpts, uint32, uint16, []*big.Int) error); ok {
 		r1 = rf(blockManager, opts, epoch, leafId, sortedValues)
 	} else {
 		r1 = ret.Error(1)
@@ -182,11 +182,11 @@ func (_m *BlockManagerInterface) GiveSorted(blockManager *bindings.BlockManager,
 }
 
 // Propose provides a mock function with given fields: client, opts, epoch, ids, medians, iteration, biggestInfluencerId
-func (_m *BlockManagerInterface) Propose(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, ids []uint16, medians []uint32, iteration *big.Int, biggestInfluencerId uint32) (*types.Transaction, error) {
+func (_m *BlockManagerInterface) Propose(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, ids []uint16, medians []*big.Int, iteration *big.Int, biggestInfluencerId uint32) (*types.Transaction, error) {
 	ret := _m.Called(client, opts, epoch, ids, medians, iteration, biggestInfluencerId)
 
 	var r0 *types.Transaction
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, *bind.TransactOpts, uint32, []uint16, []uint32, *big.Int, uint32) *types.Transaction); ok {
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, *bind.TransactOpts, uint32, []uint16, []*big.Int, *big.Int, uint32) *types.Transaction); ok {
 		r0 = rf(client, opts, epoch, ids, medians, iteration, biggestInfluencerId)
 	} else {
 		if ret.Get(0) != nil {
@@ -195,7 +195,7 @@ func (_m *BlockManagerInterface) Propose(client *ethclient.Client, opts *bind.Tr
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, *bind.TransactOpts, uint32, []uint16, []uint32, *big.Int, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(*ethclient.Client, *bind.TransactOpts, uint32, []uint16, []*big.Int, *big.Int, uint32) error); ok {
 		r1 = rf(client, opts, epoch, ids, medians, iteration, biggestInfluencerId)
 	} else {
 		r1 = ret.Error(1)

--- a/cmd/mocks/utils_cmd_interface.go
+++ b/cmd/mocks/utils_cmd_interface.go
@@ -365,11 +365,11 @@ func (_m *UtilsCmdInterface) Delegate(txnArgs types.TransactionOptions, stakerId
 }
 
 // Dispute provides a mock function with given fields: client, config, account, epoch, blockIndex, proposedBlock, leafId, sortedValues
-func (_m *UtilsCmdInterface) Dispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockIndex uint8, proposedBlock bindings.StructsBlock, leafId uint16, sortedValues []uint32) error {
+func (_m *UtilsCmdInterface) Dispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockIndex uint8, proposedBlock bindings.StructsBlock, leafId uint16, sortedValues []*big.Int) error {
 	ret := _m.Called(client, config, account, epoch, blockIndex, proposedBlock, leafId, sortedValues)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, uint8, bindings.StructsBlock, uint16, []uint32) error); ok {
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, uint8, bindings.StructsBlock, uint16, []*big.Int) error); ok {
 		r0 = rf(client, config, account, epoch, blockIndex, proposedBlock, leafId, sortedValues)
 	} else {
 		r0 = ret.Error(0)
@@ -745,15 +745,15 @@ func (_m *UtilsCmdInterface) GetLastProposedEpoch(client *ethclient.Client, bloc
 }
 
 // GetLocalMediansData provides a mock function with given fields: client, account, epoch, blockNumber, rogueData
-func (_m *UtilsCmdInterface) GetLocalMediansData(client *ethclient.Client, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) ([]uint32, []uint16, *types.RevealedDataMaps, error) {
+func (_m *UtilsCmdInterface) GetLocalMediansData(client *ethclient.Client, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) ([]*big.Int, []uint16, *types.RevealedDataMaps, error) {
 	ret := _m.Called(client, account, epoch, blockNumber, rogueData)
 
-	var r0 []uint32
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Account, uint32, *big.Int, types.Rogue) []uint32); ok {
+	var r0 []*big.Int
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Account, uint32, *big.Int, types.Rogue) []*big.Int); ok {
 		r0 = rf(client, account, epoch, blockNumber, rogueData)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]uint32)
+			r0 = ret.Get(0).([]*big.Int)
 		}
 	}
 
@@ -930,7 +930,7 @@ func (_m *UtilsCmdInterface) GetWaitTime() (int32, error) {
 }
 
 // GiveSorted provides a mock function with given fields: client, blockManager, txnOpts, epoch, assetId, sortedStakers
-func (_m *UtilsCmdInterface) GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []uint32) {
+func (_m *UtilsCmdInterface) GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []*big.Int) {
 	_m.Called(client, blockManager, txnOpts, epoch, assetId, sortedStakers)
 }
 
@@ -1202,15 +1202,15 @@ func (_m *UtilsCmdInterface) ListAccounts() ([]accounts.Account, error) {
 }
 
 // MakeBlock provides a mock function with given fields: client, blockNumber, epoch, rogueData
-func (_m *UtilsCmdInterface) MakeBlock(client *ethclient.Client, blockNumber *big.Int, epoch uint32, rogueData types.Rogue) ([]uint32, []uint16, *types.RevealedDataMaps, error) {
+func (_m *UtilsCmdInterface) MakeBlock(client *ethclient.Client, blockNumber *big.Int, epoch uint32, rogueData types.Rogue) ([]*big.Int, []uint16, *types.RevealedDataMaps, error) {
 	ret := _m.Called(client, blockNumber, epoch, rogueData)
 
-	var r0 []uint32
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, *big.Int, uint32, types.Rogue) []uint32); ok {
+	var r0 []*big.Int
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, *big.Int, uint32, types.Rogue) []*big.Int); ok {
 		r0 = rf(client, blockNumber, epoch, rogueData)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]uint32)
+			r0 = ret.Get(0).([]*big.Int)
 		}
 	}
 

--- a/cmd/mocks/utils_interface.go
+++ b/cmd/mocks/utils_interface.go
@@ -1174,14 +1174,16 @@ func (_m *UtilsInterface) GetUpdatedStaker(client *ethclient.Client, stakerId ui
 }
 
 // GetVoteValue provides a mock function with given fields: client, epoch, stakerId, medianIndex
-func (_m *UtilsInterface) GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (uint32, error) {
+func (_m *UtilsInterface) GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (*big.Int, error) {
 	ret := _m.Called(client, epoch, stakerId, medianIndex)
 
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint32, uint32, uint16) uint32); ok {
+	var r0 *big.Int
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint32, uint32, uint16) *big.Int); ok {
 		r0 = rf(client, epoch, stakerId, medianIndex)
 	} else {
-		r0 = ret.Get(0).(uint32)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
 	}
 
 	var r1 error

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -65,7 +65,7 @@ func TestPropose(t *testing.T) {
 		lastIteration              *big.Int
 		lastProposedBlockStruct    bindings.StructsBlock
 		lastProposedBlockStructErr error
-		medians                    []uint32
+		medians                    []*big.Int
 		ids                        []uint16
 		revealDataMaps             *types.RevealedDataMaps
 		mediansErr                 error
@@ -98,7 +98,7 @@ func TestPropose(t *testing.T) {
 				maxAltBlocks:            4,
 				lastIteration:           big.NewInt(5),
 				lastProposedBlockStruct: bindings.StructsBlock{},
-				medians:                 []uint32{6701548, 478307},
+				medians:                 []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:                 txnOpts,
 				proposeTxn:              &Types.Transaction{},
 				hash:                    common.BigToHash(big.NewInt(1)),
@@ -120,7 +120,7 @@ func TestPropose(t *testing.T) {
 				maxAltBlocks:            4,
 				lastIteration:           big.NewInt(5),
 				lastProposedBlockStruct: bindings.StructsBlock{},
-				medians:                 []uint32{6701548, 478307},
+				medians:                 []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:                 txnOpts,
 				proposeTxn:              &Types.Transaction{},
 				hash:                    common.BigToHash(big.NewInt(1)),
@@ -142,7 +142,7 @@ func TestPropose(t *testing.T) {
 				maxAltBlocks:            4,
 				lastIteration:           big.NewInt(5),
 				lastProposedBlockStruct: bindings.StructsBlock{},
-				medians:                 []uint32{6701548, 478307},
+				medians:                 []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:                 txnOpts,
 				proposeTxn:              &Types.Transaction{},
 				hash:                    common.BigToHash(big.NewInt(1)),
@@ -163,7 +163,7 @@ func TestPropose(t *testing.T) {
 				maxAltBlocks:            4,
 				lastIteration:           big.NewInt(5),
 				lastProposedBlockStruct: bindings.StructsBlock{},
-				medians:                 []uint32{6701548, 478307},
+				medians:                 []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:                 txnOpts,
 				proposeTxn:              &Types.Transaction{},
 				hash:                    common.BigToHash(big.NewInt(1)),
@@ -185,7 +185,7 @@ func TestPropose(t *testing.T) {
 				maxAltBlocks:            4,
 				lastIteration:           big.NewInt(5),
 				lastProposedBlockStruct: bindings.StructsBlock{},
-				medians:                 []uint32{6701548, 478307},
+				medians:                 []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:                 txnOpts,
 				proposeTxn:              &Types.Transaction{},
 				hash:                    common.BigToHash(big.NewInt(1)),
@@ -207,7 +207,7 @@ func TestPropose(t *testing.T) {
 				maxAltBlocks:            4,
 				lastIteration:           big.NewInt(5),
 				lastProposedBlockStruct: bindings.StructsBlock{},
-				medians:                 []uint32{6701548, 478307},
+				medians:                 []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:                 txnOpts,
 				proposeTxn:              &Types.Transaction{},
 				hash:                    common.BigToHash(big.NewInt(1)),
@@ -229,7 +229,7 @@ func TestPropose(t *testing.T) {
 				maxAltBlocks:            4,
 				lastIteration:           big.NewInt(5),
 				lastProposedBlockStruct: bindings.StructsBlock{},
-				medians:                 []uint32{6701548, 478307},
+				medians:                 []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:                 txnOpts,
 				proposeTxn:              &Types.Transaction{},
 				hash:                    common.BigToHash(big.NewInt(1)),
@@ -251,7 +251,7 @@ func TestPropose(t *testing.T) {
 				maxAltBlocksErr:         errors.New("maxAltBlocks error"),
 				lastIteration:           big.NewInt(5),
 				lastProposedBlockStruct: bindings.StructsBlock{},
-				medians:                 []uint32{6701548, 478307},
+				medians:                 []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:                 txnOpts,
 				proposeTxn:              &Types.Transaction{},
 				hash:                    common.BigToHash(big.NewInt(1)),
@@ -273,7 +273,7 @@ func TestPropose(t *testing.T) {
 				maxAltBlocks:               2,
 				lastIteration:              big.NewInt(5),
 				lastProposedBlockStructErr: errors.New("lastProposedBlockStruct error"),
-				medians:                    []uint32{6701548, 478307},
+				medians:                    []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:                    txnOpts,
 				proposeTxn:                 &Types.Transaction{},
 				hash:                       common.BigToHash(big.NewInt(1)),
@@ -297,7 +297,7 @@ func TestPropose(t *testing.T) {
 				lastProposedBlockStruct: bindings.StructsBlock{
 					Iteration: big.NewInt(1),
 				},
-				medians:    []uint32{6701548, 478307},
+				medians:    []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:    txnOpts,
 				proposeTxn: &Types.Transaction{},
 				hash:       common.BigToHash(big.NewInt(1)),
@@ -321,7 +321,7 @@ func TestPropose(t *testing.T) {
 				lastProposedBlockStruct: bindings.StructsBlock{
 					Iteration: big.NewInt(2),
 				},
-				medians:    []uint32{6701548, 478307},
+				medians:    []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:    txnOpts,
 				proposeTxn: &Types.Transaction{},
 				hash:       common.BigToHash(big.NewInt(1)),
@@ -365,7 +365,7 @@ func TestPropose(t *testing.T) {
 				maxAltBlocks:            4,
 				lastIteration:           big.NewInt(5),
 				lastProposedBlockStruct: bindings.StructsBlock{},
-				medians:                 []uint32{6701548, 478307},
+				medians:                 []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:                 txnOpts,
 				proposeErr:              errors.New("propose error"),
 				hash:                    common.BigToHash(big.NewInt(1)),
@@ -387,7 +387,7 @@ func TestPropose(t *testing.T) {
 				maxAltBlocks:            4,
 				lastIteration:           big.NewInt(5),
 				lastProposedBlockStruct: bindings.StructsBlock{},
-				medians:                 []uint32{6701548, 478307},
+				medians:                 []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:                 txnOpts,
 				proposeTxn:              &Types.Transaction{},
 				fileNameErr:             errors.New("fileName error"),
@@ -409,7 +409,7 @@ func TestPropose(t *testing.T) {
 				maxAltBlocks:            4,
 				lastIteration:           big.NewInt(5),
 				lastProposedBlockStruct: bindings.StructsBlock{},
-				medians:                 []uint32{6701548, 478307},
+				medians:                 []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:                 txnOpts,
 				proposeTxn:              &Types.Transaction{},
 				saveDataErr:             errors.New("error in saving data"),
@@ -448,7 +448,7 @@ func TestPropose(t *testing.T) {
 				maxAltBlocks:            4,
 				lastIteration:           big.NewInt(5),
 				lastProposedBlockStruct: bindings.StructsBlock{},
-				medians:                 []uint32{6701548, 478307},
+				medians:                 []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				txnOpts:                 txnOpts,
 				proposeTxn:              &Types.Transaction{},
 				hash:                    common.BigToHash(big.NewInt(1)),
@@ -938,7 +938,7 @@ func TestMakeBlock(t *testing.T) {
 		epoch       uint32
 	)
 
-	randomValue := utils.GetRogueRandomMedianValue()
+	randomValue := utils.GetRogueRandomValue(10000000)
 
 	type args struct {
 		revealedDataMaps     *types.RevealedDataMaps
@@ -950,7 +950,7 @@ func TestMakeBlock(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    []uint32
+		want    []*big.Int
 		want1   []uint16
 		want2   *types.RevealedDataMaps
 		wantErr bool
@@ -959,18 +959,18 @@ func TestMakeBlock(t *testing.T) {
 			name: "Test 1: When MakeBlock executes successfully and there is no rogue mode",
 			args: args{
 				revealedDataMaps: &types.RevealedDataMaps{
-					SortedRevealedValues: map[uint16][]uint32{1: {1, 2, 3}},
-					VoteWeights:          map[uint32]*big.Int{1: big.NewInt(100)},
-					InfluenceSum:         map[uint16]*big.Int{1: big.NewInt(100)},
+					SortedRevealedValues: map[uint16][]*big.Int{0: {big.NewInt(1), big.NewInt(1)}, 1: {big.NewInt(100), big.NewInt(100)}, 2: {big.NewInt(200), big.NewInt(200)}},
+					VoteWeights:          map[string]*big.Int{big.NewInt(1).String(): big.NewInt(1000), big.NewInt(1).String(): big.NewInt(1000), big.NewInt(100).String(): big.NewInt(2000), big.NewInt(100).String(): big.NewInt(2000), big.NewInt(200).String(): big.NewInt(3000), big.NewInt(200).String(): big.NewInt(3000)},
+					InfluenceSum:         map[uint16]*big.Int{0: big.NewInt(500), 1: big.NewInt(10000), 2: big.NewInt(10000), 3: big.NewInt(10000)},
 				},
-				activeCollections: []uint16{1, 2},
+				activeCollections: []uint16{0, 1, 2},
 			},
-			want:  []uint32{1},
-			want1: []uint16{2},
+			want:  []*big.Int{big.NewInt(1), big.NewInt(100), big.NewInt(200)},
+			want1: []uint16{0, 1, 2},
 			want2: &types.RevealedDataMaps{
-				SortedRevealedValues: map[uint16][]uint32{1: {1, 2, 3}},
-				VoteWeights:          map[uint32]*big.Int{1: big.NewInt(100)},
-				InfluenceSum:         map[uint16]*big.Int{1: big.NewInt(50)},
+				SortedRevealedValues: map[uint16][]*big.Int{0: {big.NewInt(1), big.NewInt(1)}, 1: {big.NewInt(100), big.NewInt(100)}, 2: {big.NewInt(200), big.NewInt(200)}},
+				VoteWeights:          map[string]*big.Int{big.NewInt(1).String(): big.NewInt(1000), big.NewInt(1).String(): big.NewInt(1000), big.NewInt(100).String(): big.NewInt(2000), big.NewInt(100).String(): big.NewInt(2000), big.NewInt(200).String(): big.NewInt(3000), big.NewInt(200).String(): big.NewInt(3000)},
+				InfluenceSum:         map[uint16]*big.Int{0: big.NewInt(250), 1: big.NewInt(2500), 2: big.NewInt(2500), 3: big.NewInt(10000)},
 			},
 			wantErr: false,
 		},
@@ -999,8 +999,8 @@ func TestMakeBlock(t *testing.T) {
 			name: "Test 4: When MakeBlock executes successfully and there is missingIds rogue mode",
 			args: args{
 				revealedDataMaps: &types.RevealedDataMaps{
-					SortedRevealedValues: map[uint16][]uint32{1: {1, 2, 3}},
-					VoteWeights:          map[uint32]*big.Int{1: big.NewInt(100)},
+					SortedRevealedValues: map[uint16][]*big.Int{1: {big.NewInt(1), big.NewInt(2), big.NewInt(3)}},
+					VoteWeights:          map[string]*big.Int{big.NewInt(1).String(): big.NewInt(100)},
 					InfluenceSum:         map[uint16]*big.Int{1: big.NewInt(100)},
 				},
 				activeCollections: []uint16{1, 2},
@@ -1009,11 +1009,11 @@ func TestMakeBlock(t *testing.T) {
 					RogueMode: []string{"missingIds"},
 				},
 			},
-			want:  []uint32{1},
+			want:  []*big.Int{big.NewInt(1)},
 			want1: []uint16{3},
 			want2: &types.RevealedDataMaps{
-				SortedRevealedValues: map[uint16][]uint32{1: {1, 2, 3}},
-				VoteWeights:          map[uint32]*big.Int{1: big.NewInt(100)},
+				SortedRevealedValues: map[uint16][]*big.Int{1: {big.NewInt(1), big.NewInt(2), big.NewInt(3)}},
+				VoteWeights:          map[string]*big.Int{big.NewInt(1).String(): big.NewInt(100)},
 				InfluenceSum:         map[uint16]*big.Int{1: big.NewInt(50)},
 			},
 			wantErr: false,
@@ -1022,8 +1022,8 @@ func TestMakeBlock(t *testing.T) {
 			name: "Test 5: When MakeBlock executes successfully and there is extraIds rogue mode",
 			args: args{
 				revealedDataMaps: &types.RevealedDataMaps{
-					SortedRevealedValues: map[uint16][]uint32{1: {1, 2, 3}},
-					VoteWeights:          map[uint32]*big.Int{1: big.NewInt(100)},
+					SortedRevealedValues: map[uint16][]*big.Int{1: {big.NewInt(1), big.NewInt(2), big.NewInt(3)}},
+					VoteWeights:          map[string]*big.Int{big.NewInt(1).String(): big.NewInt(100)},
 					InfluenceSum:         map[uint16]*big.Int{1: big.NewInt(100)},
 				},
 				activeCollections: []uint16{1, 2},
@@ -1032,11 +1032,11 @@ func TestMakeBlock(t *testing.T) {
 					RogueMode: []string{"extraIds"},
 				},
 			},
-			want:  []uint32{1, randomValue},
+			want:  []*big.Int{big.NewInt(1), randomValue},
 			want1: []uint16{2, 3},
 			want2: &types.RevealedDataMaps{
-				SortedRevealedValues: map[uint16][]uint32{1: {1, 2, 3}},
-				VoteWeights:          map[uint32]*big.Int{1: big.NewInt(100)},
+				SortedRevealedValues: map[uint16][]*big.Int{1: {big.NewInt(1), big.NewInt(2), big.NewInt(3)}},
+				VoteWeights:          map[string]*big.Int{big.NewInt(1).String(): big.NewInt(100)},
 				InfluenceSum:         map[uint16]*big.Int{1: big.NewInt(50)},
 			},
 			wantErr: false,
@@ -1045,8 +1045,8 @@ func TestMakeBlock(t *testing.T) {
 			name: "Test 5: When MakeBlock executes successfully and there is medians rogue mode",
 			args: args{
 				revealedDataMaps: &types.RevealedDataMaps{
-					SortedRevealedValues: map[uint16][]uint32{1: {1, 2, 3}},
-					VoteWeights:          map[uint32]*big.Int{1: big.NewInt(100)},
+					SortedRevealedValues: map[uint16][]*big.Int{1: {big.NewInt(1), big.NewInt(2), big.NewInt(3)}},
+					VoteWeights:          map[string]*big.Int{big.NewInt(1).String(): big.NewInt(100)},
 					InfluenceSum:         map[uint16]*big.Int{1: big.NewInt(100)},
 				},
 				activeCollections: []uint16{1, 2},
@@ -1055,11 +1055,11 @@ func TestMakeBlock(t *testing.T) {
 					RogueMode: []string{"medians"},
 				},
 			},
-			want:  []uint32{randomValue},
+			want:  []*big.Int{randomValue},
 			want1: []uint16{2},
 			want2: &types.RevealedDataMaps{
-				SortedRevealedValues: map[uint16][]uint32{1: {1, 2, 3}},
-				VoteWeights:          map[uint32]*big.Int{1: big.NewInt(100)},
+				SortedRevealedValues: map[uint16][]*big.Int{1: {big.NewInt(1), big.NewInt(2), big.NewInt(3)}},
+				VoteWeights:          map[string]*big.Int{big.NewInt(1).String(): big.NewInt(100)},
 				InfluenceSum:         map[uint16]*big.Int{1: big.NewInt(100)},
 			},
 			wantErr: false,
@@ -1075,7 +1075,7 @@ func TestMakeBlock(t *testing.T) {
 
 			cmdUtilsMock.On("GetSortedRevealedValues", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.revealedDataMaps, tt.args.revealedDataMapsErr)
 			utilsMock.On("GetActiveCollections", mock.Anything).Return(tt.args.activeCollections, tt.args.activeCollectionsErr)
-			utilsMock.On("GetRogueRandomMedianValue").Return(randomValue)
+			utilsMock.On("GetRogueRandomValue", mock.Anything).Return(randomValue)
 			ut := &UtilsStruct{}
 			got, got1, got2, err := ut.MakeBlock(client, blockNumber, epoch, tt.args.rogueData)
 			if (err != nil) != tt.wantErr {
@@ -1115,11 +1115,11 @@ func TestGetSortedRevealedValues(t *testing.T) {
 		{
 			name: "Test 1: When GetSortedRevealedValues executes successfully",
 			args: args{
-				assignedAssets: []types.RevealedStruct{{RevealedValues: []types.AssignedAsset{{LeafId: 1, Value: 100}}, Influence: big.NewInt(100)}},
+				assignedAssets: []types.RevealedStruct{{RevealedValues: []types.AssignedAsset{{LeafId: 1, Value: big.NewInt(100)}}, Influence: big.NewInt(100)}},
 			},
 			want: &types.RevealedDataMaps{
-				SortedRevealedValues: map[uint16][]uint32{1: {100}},
-				VoteWeights:          map[uint32]*big.Int{100: big.NewInt(100)},
+				SortedRevealedValues: map[uint16][]*big.Int{1: {big.NewInt(100)}},
+				VoteWeights:          map[string]*big.Int{big.NewInt(100).String(): big.NewInt(100)},
 				InfluenceSum:         map[uint16]*big.Int{1: big.NewInt(100)},
 			},
 			wantErr: false,
@@ -1317,11 +1317,11 @@ func BenchmarkMakeBlock(b *testing.B) {
 				razorUtils = utilsMock
 				cmdUtils = cmdUtilsMock
 
-				votes := GetUint32DummyVotes(v.numOfVotes)
+				votes := GetDummyVotes(v.numOfVotes)
 
 				cmdUtilsMock.On("GetSortedRevealedValues", mock.Anything, mock.Anything, mock.Anything).Return(&types.RevealedDataMaps{
-					SortedRevealedValues: map[uint16][]uint32{0: votes},
-					VoteWeights:          map[uint32]*big.Int{100: big.NewInt(100)},
+					SortedRevealedValues: map[uint16][]*big.Int{0: votes},
+					VoteWeights:          map[string]*big.Int{big.NewInt(100).String(): big.NewInt(100)},
 					InfluenceSum:         map[uint16]*big.Int{0: big.NewInt(100)},
 				}, nil)
 				utilsMock.On("GetActiveCollections", mock.Anything).Return([]uint16{1}, nil)
@@ -1343,14 +1343,6 @@ func GetDummyVotes(numOfVotes int) []*big.Int {
 	return result
 }
 
-func GetUint32DummyVotes(numOfVotes int) []uint32 {
-	var result []uint32
-	for i := 0; i < numOfVotes; i++ {
-		result = append(result, 100)
-	}
-	return result
-}
-
 func GetDummyAssignedAssets(asset types.RevealedStruct, numOfAssignedAssets int) []types.RevealedStruct {
 	var assignedAssets []types.RevealedStruct
 	for i := 1; i <= numOfAssignedAssets; i++ {
@@ -1365,7 +1357,7 @@ func GetDummyRevealedValues(numOfRevealedValues uint16) types.RevealedStruct {
 	for i = 1; i < numOfRevealedValues; i++ {
 		revealedValues = append(revealedValues, types.AssignedAsset{
 			LeafId: i,
-			Value:  1000,
+			Value:  big.NewInt(1000),
 		})
 	}
 	return types.RevealedStruct{

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -960,7 +960,7 @@ func TestMakeBlock(t *testing.T) {
 			args: args{
 				revealedDataMaps: &types.RevealedDataMaps{
 					SortedRevealedValues: map[uint16][]*big.Int{0: {big.NewInt(1), big.NewInt(1)}, 1: {big.NewInt(100), big.NewInt(100)}, 2: {big.NewInt(200), big.NewInt(200)}},
-					VoteWeights:          map[string]*big.Int{big.NewInt(1).String(): big.NewInt(1000), big.NewInt(1).String(): big.NewInt(1000), big.NewInt(100).String(): big.NewInt(2000), big.NewInt(100).String(): big.NewInt(2000), big.NewInt(200).String(): big.NewInt(3000), big.NewInt(200).String(): big.NewInt(3000)},
+					VoteWeights:          map[string]*big.Int{big.NewInt(1).String(): big.NewInt(1000), big.NewInt(100).String(): big.NewInt(2000), big.NewInt(200).String(): big.NewInt(3000)},
 					InfluenceSum:         map[uint16]*big.Int{0: big.NewInt(500), 1: big.NewInt(10000), 2: big.NewInt(10000), 3: big.NewInt(10000)},
 				},
 				activeCollections: []uint16{0, 1, 2},
@@ -1321,7 +1321,7 @@ func BenchmarkMakeBlock(b *testing.B) {
 
 				cmdUtilsMock.On("GetSortedRevealedValues", mock.Anything, mock.Anything, mock.Anything).Return(&types.RevealedDataMaps{
 					SortedRevealedValues: map[uint16][]*big.Int{0: votes},
-					VoteWeights:          map[string]*big.Int{big.NewInt(100).String(): big.NewInt(100)},
+					VoteWeights:          map[string]*big.Int{(big.NewInt(1).Mul(big.NewInt(697718000), big.NewInt(1e18))).String(): big.NewInt(100)},
 					InfluenceSum:         map[uint16]*big.Int{0: big.NewInt(100)},
 				}, nil)
 				utilsMock.On("GetActiveCollections", mock.Anything).Return([]uint16{1}, nil)

--- a/cmd/reveal.go
+++ b/cmd/reveal.go
@@ -80,7 +80,7 @@ func (*UtilsStruct) GenerateTreeRevealData(merkleTree [][][]byte, commitData typ
 	for i := 0; i < len(commitData.SeqAllottedCollections); i++ {
 		value := bindings.StructsAssignedAsset{
 			LeafId: uint16(commitData.SeqAllottedCollections[i].Uint64()),
-			Value:  uint32(commitData.Leaves[commitData.SeqAllottedCollections[i].Uint64()].Uint64()),
+			Value:  big.NewInt(commitData.Leaves[commitData.SeqAllottedCollections[i].Uint64()].Int64()),
 		}
 		proof := utils.MerkleInterface.GetProofPath(merkleTree, value.LeafId)
 		values = append(values, value)
@@ -123,8 +123,8 @@ func (*UtilsStruct) IndexRevealEventsOfCurrentEpoch(client *ethclient.Client, bl
 		}
 		if epoch == data[0].(uint32) {
 			treeValues := data[3].([]struct {
-				LeafId uint16 `json:"leafId"`
-				Value  uint32 `json:"value"`
+				LeafId uint16   `json:"leafId"`
+				Value  *big.Int `json:"value"`
 			})
 			var revealedValues []types.AssignedAsset
 			for _, value := range treeValues {

--- a/cmd/reveal_test.go
+++ b/cmd/reveal_test.go
@@ -232,7 +232,7 @@ func TestGenerateTreeRevealData(t *testing.T) {
 				root:  [32]byte{},
 			},
 			want: bindings.StructsMerkleTree{
-				Values: []bindings.StructsAssignedAsset{{LeafId: 1, Value: 2}},
+				Values: []bindings.StructsAssignedAsset{{LeafId: 1, Value: big.NewInt(2)}},
 				Proofs: [][][32]byte{{}},
 				Root:   [32]byte{},
 			},

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -234,7 +234,7 @@ func (u Utils) GetEpochLastRevealed(client *ethclient.Client, stakerId uint32) (
 	return utilsInterface.GetEpochLastRevealed(client, stakerId)
 }
 
-func (u Utils) GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (uint32, error) {
+func (u Utils) GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (*big.Int, error) {
 	return utilsInterface.GetVoteValue(client, epoch, stakerId, medianIndex)
 }
 
@@ -534,7 +534,7 @@ func (blockManagerUtils BlockManagerUtils) DisputeOnOrderOfIds(client *ethclient
 	return txn, nil
 }
 
-func (blockManagerUtils BlockManagerUtils) Propose(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, ids []uint16, medians []uint32, iteration *big.Int, biggestInfluencerId uint32) (*Types.Transaction, error) {
+func (blockManagerUtils BlockManagerUtils) Propose(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, ids []uint16, medians []*big.Int, iteration *big.Int, biggestInfluencerId uint32) (*Types.Transaction, error) {
 	blockManager := utilsInterface.GetBlockManager(client)
 	var (
 		txn *Types.Transaction
@@ -554,7 +554,7 @@ func (blockManagerUtils BlockManagerUtils) Propose(client *ethclient.Client, opt
 	return txn, nil
 }
 
-func (blockManagerUtils BlockManagerUtils) GiveSorted(blockManager *bindings.BlockManager, opts *bind.TransactOpts, epoch uint32, leafId uint16, sortedValues []uint32) (*Types.Transaction, error) {
+func (blockManagerUtils BlockManagerUtils) GiveSorted(blockManager *bindings.BlockManager, opts *bind.TransactOpts, epoch uint32, leafId uint16, sortedValues []*big.Int) (*Types.Transaction, error) {
 	return blockManager.GiveSorted(opts, epoch, leafId, sortedValues)
 }
 
@@ -813,7 +813,7 @@ func (c CryptoUtils) HexToECDSA(hexKey string) (*ecdsa.PrivateKey, error) {
 	return crypto.HexToECDSA(hexKey)
 }
 
-func (*UtilsStruct) GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []uint32) {
+func (*UtilsStruct) GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []*big.Int) {
 	GiveSorted(client, blockManager, txnOpts, epoch, assetId, sortedStakers)
 }
 

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -242,10 +242,6 @@ func (u Utils) GetTotalInfluenceRevealed(client *ethclient.Client, epoch uint32,
 	return utilsInterface.GetTotalInfluenceRevealed(client, epoch, medianIndex)
 }
 
-func (u Utils) ConvertBigIntArrayToUint32Array(bigIntArray []*big.Int) []uint32 {
-	return utils.ConvertBigIntArrayToUint32Array(bigIntArray)
-}
-
 func (u Utils) ConvertUint32ArrayToBigIntArray(uint32Array []uint32) []*big.Int {
 	return utils.ConvertUint32ArrayToBigIntArray(uint32Array)
 }

--- a/core/types/assets.go
+++ b/core/types/assets.go
@@ -45,8 +45,8 @@ type StructsJob struct {
 }
 
 type AssignedAsset struct {
-	LeafId uint16 `json:"leafId"`
-	Value  uint32 `json:"value"`
+	LeafId uint16   `json:"leafId"`
+	Value  *big.Int `json:"value"`
 }
 
 type CustomJob struct {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -1,8 +1,11 @@
 package types
 
-import "razor/pkg/bindings"
+import (
+	"math/big"
+	"razor/pkg/bindings"
+)
 
 type Block struct {
 	Block        bindings.StructsBlock
-	BlockMedians []uint32
+	BlockMedians []*big.Int
 }

--- a/core/types/vote.go
+++ b/core/types/vote.go
@@ -34,8 +34,8 @@ type RevealedStruct struct {
 }
 
 type RevealedDataMaps struct {
-	SortedRevealedValues map[uint16][]uint32
-	VoteWeights          map[uint32]*big.Int
+	SortedRevealedValues map[uint16][]*big.Int
+	VoteWeights          map[*big.Int]*big.Int
 	InfluenceSum         map[uint16]*big.Int
 }
 

--- a/core/types/vote.go
+++ b/core/types/vote.go
@@ -35,7 +35,7 @@ type RevealedStruct struct {
 
 type RevealedDataMaps struct {
 	SortedRevealedValues map[uint16][]*big.Int
-	VoteWeights          map[*big.Int]*big.Int
+	VoteWeights          map[string]*big.Int
 	InfluenceSum         map[uint16]*big.Int
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "razor-go",
-  "version": "v0.2.0",
+  "version": "v1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "v0.2.0",
+      "name": "razor-go",
+      "version": "v1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@razor-network/contracts": "1.0.1"
+        "@razor-network/contracts": "1.0.1-patch3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -717,9 +718,9 @@
       }
     },
     "node_modules/@razor-network/contracts": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@razor-network/contracts/-/contracts-1.0.1.tgz",
-      "integrity": "sha512-K4IbJzr3VTw2UpbnZa54SKpAWwaJX+JmABO4b+p44n4qzzRUcdsgNXs3qHPqRaZhx42WJU5L5Js2oGVA0/3mhQ==",
+      "version": "1.0.1-patch3",
+      "resolved": "https://registry.npmjs.org/@razor-network/contracts/-/contracts-1.0.1-patch3.tgz",
+      "integrity": "sha512-XW571h1WklcJbHM+1WTI8WOVaVI4e4R0nbZ2CyZGVpwKUdOpPTjA/W/cxOmiYVvco+NMd8ngrZsmu2Rxt3POKg==",
       "hasInstallScript": true,
       "dependencies": {
         "@openzeppelin/contracts": "4.5.0",
@@ -9784,9 +9785,9 @@
       }
     },
     "@razor-network/contracts": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@razor-network/contracts/-/contracts-1.0.1.tgz",
-      "integrity": "sha512-K4IbJzr3VTw2UpbnZa54SKpAWwaJX+JmABO4b+p44n4qzzRUcdsgNXs3qHPqRaZhx42WJU5L5Js2oGVA0/3mhQ==",
+      "version": "1.0.1-patch3",
+      "resolved": "https://registry.npmjs.org/@razor-network/contracts/-/contracts-1.0.1-patch3.tgz",
+      "integrity": "sha512-XW571h1WklcJbHM+1WTI8WOVaVI4e4R0nbZ2CyZGVpwKUdOpPTjA/W/cxOmiYVvco+NMd8ngrZsmu2Rxt3POKg==",
       "requires": {
         "@openzeppelin/contracts": "4.5.0",
         "@primitivefi/hardhat-dodoc": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/razor-network/razor-go#readme",
   "dependencies": {
-    "@razor-network/contracts": "1.0.1"
+    "@razor-network/contracts": "1.0.1-patch3"
   }
 }

--- a/utils/array.go
+++ b/utils/array.go
@@ -36,14 +36,14 @@ func Contains(slice interface{}, val interface{}) bool {
 	return false
 }
 
-func IsEqualUint32(arr1 []uint32, arr2 []uint32) (bool, int) {
+func IsEqual(arr1 []*big.Int, arr2 []*big.Int) (bool, int) {
 	if len(arr1) > len(arr2) {
 		return false, len(arr2)
 	} else if len(arr1) < len(arr2) {
 		return false, len(arr1)
 	}
 	for i := 0; i < len(arr1); i++ {
-		if arr2[i] != arr1[i] {
+		if arr2[i].Cmp(arr1[i]) != 0 {
 			return false, i
 		}
 	}
@@ -108,14 +108,6 @@ func GetDataInBytes(data []*big.Int) [][]byte {
 		dataInBytes = append(dataInBytes, math2.U256Bytes(datum))
 	}
 	return dataInBytes
-}
-
-func ConvertBigIntArrayToUint32Array(bigIntArray []*big.Int) []uint32 {
-	var arr []uint32
-	for _, datum := range bigIntArray {
-		arr = append(arr, uint32(datum.Int64()))
-	}
-	return arr
 }
 
 func ConvertUint32ArrayToBigIntArray(uint32Array []uint32) []*big.Int {

--- a/utils/array_test.go
+++ b/utils/array_test.go
@@ -137,8 +137,8 @@ func TestGetDataInBytes(t *testing.T) {
 
 func TestIsEqual(t *testing.T) {
 	type args struct {
-		arr1 []uint32
-		arr2 []uint32
+		arr1 []*big.Int
+		arr2 []*big.Int
 	}
 	tests := []struct {
 		name  string
@@ -149,8 +149,8 @@ func TestIsEqual(t *testing.T) {
 		{
 			name: "Test when both arrays have same values but at different positions",
 			args: args{
-				arr1: []uint32{1, 1234, 2321},
-				arr2: []uint32{1234, 1, 2321},
+				arr1: []*big.Int{big.NewInt(1), big.NewInt(1234), big.NewInt(2321)},
+				arr2: []*big.Int{big.NewInt(1234), big.NewInt(1), big.NewInt(2321)},
 			},
 			want:  false,
 			want1: 0,
@@ -158,8 +158,8 @@ func TestIsEqual(t *testing.T) {
 		{
 			name: "Test when both arrays have different length and len(arr1) < len(arr2)",
 			args: args{
-				arr1: []uint32{1, 1234},
-				arr2: []uint32{1234, 1, 2321},
+				arr1: []*big.Int{big.NewInt(1), big.NewInt(1234)},
+				arr2: []*big.Int{big.NewInt(1234), big.NewInt(1), big.NewInt(2321)},
 			},
 			want:  false,
 			want1: 2,
@@ -167,8 +167,8 @@ func TestIsEqual(t *testing.T) {
 		{
 			name: "Test when both arrays have different length and len(arr1) > len(arr2)",
 			args: args{
-				arr1: []uint32{1234, 1, 2321},
-				arr2: []uint32{1, 1234},
+				arr1: []*big.Int{big.NewInt(1234), big.NewInt(1), big.NewInt(2321)},
+				arr2: []*big.Int{big.NewInt(1), big.NewInt(1234)},
 			},
 			want:  false,
 			want1: 2,
@@ -176,8 +176,8 @@ func TestIsEqual(t *testing.T) {
 		{
 			name: "Test when both arrays are empty",
 			args: args{
-				arr1: []uint32{},
-				arr2: []uint32{},
+				arr1: []*big.Int{},
+				arr2: []*big.Int{},
 			},
 			want:  true,
 			want1: -1,
@@ -185,8 +185,8 @@ func TestIsEqual(t *testing.T) {
 		{
 			name: "Test when both arrays are exactly identical",
 			args: args{
-				arr1: []uint32{1, 1232, 12423},
-				arr2: []uint32{1, 1232, 12423},
+				arr1: []*big.Int{big.NewInt(1), big.NewInt(1232), big.NewInt(12423)},
+				arr2: []*big.Int{big.NewInt(1), big.NewInt(1232), big.NewInt(12423)},
 			},
 			want:  true,
 			want1: -1,
@@ -195,7 +195,7 @@ func TestIsEqual(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			got, got1 := IsEqualUint32(tt.args.arr1, tt.args.arr2)
+			got, got1 := IsEqual(tt.args.arr1, tt.args.arr2)
 			if got != tt.want {
 				t.Errorf("IsEqualUint32() got = %v, want %v", got, tt.want)
 			}
@@ -241,46 +241,6 @@ func TestCalculateSumOfUint8Array(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := CalculateSumOfUint8Array(tt.args.data); got != tt.want {
 				t.Errorf("CalculateSumOfUint8Array() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestConvertBigIntArrayToUint32Array(t *testing.T) {
-	type args struct {
-		data []*big.Int
-	}
-	tests := []struct {
-		name string
-		args args
-		want []uint32
-	}{
-		{
-			name: "Test when array has length more than 1",
-			args: args{
-				data: []*big.Int{big.NewInt(100), big.NewInt(200), big.NewInt(300)},
-			},
-			want: []uint32{100, 200, 300},
-		},
-		{
-			name: "Test when array has length 1",
-			args: args{
-				data: []*big.Int{big.NewInt(100)},
-			},
-			want: []uint32{100},
-		},
-		{
-			name: "Test when array is nil",
-			args: args{
-				data: nil,
-			},
-			want: nil,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := ConvertBigIntArrayToUint32Array(tt.args.data); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ConvertBigIntArrayToUint32Array() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/utils/asset.go
+++ b/utils/asset.go
@@ -211,7 +211,7 @@ func (*UtilsStruct) Aggregate(client *ethclient.Client, previousEpoch uint32, co
 		if err != nil {
 			return nil, err
 		}
-		return big.NewInt(int64(prevCommitmentData)), nil
+		return prevCommitmentData, nil
 	}
 	return performAggregation(dataToCommit, weight, collection.AggregationMethod)
 }

--- a/utils/asset_test.go
+++ b/utils/asset_test.go
@@ -45,7 +45,7 @@ func TestAggregate(t *testing.T) {
 		dataToCommit          []*big.Int
 		dataToCommitErr       error
 		weight                []uint8
-		prevCommitmentData    uint32
+		prevCommitmentData    *big.Int
 		prevCommitmentDataErr error
 		assetFilePath         string
 		assetFilePathErr      error
@@ -70,7 +70,7 @@ func TestAggregate(t *testing.T) {
 				activeJob:          job,
 				dataToCommit:       []*big.Int{big.NewInt(2)},
 				weight:             []uint8{100},
-				prevCommitmentData: 1,
+				prevCommitmentData: big.NewInt(1),
 				assetFilePath:      "",
 				statErr:            nil,
 			},
@@ -84,7 +84,7 @@ func TestAggregate(t *testing.T) {
 				activeJobErr:       errors.New("activeJob error"),
 				dataToCommit:       []*big.Int{big.NewInt(2)},
 				weight:             []uint8{100},
-				prevCommitmentData: 1,
+				prevCommitmentData: big.NewInt(1),
 				assetFilePath:      "",
 				statErr:            errors.New(""),
 			},
@@ -98,7 +98,7 @@ func TestAggregate(t *testing.T) {
 				activeJob:          job,
 				dataToCommitErr:    errors.New("dataToCommit error"),
 				weight:             []uint8{100},
-				prevCommitmentData: 1,
+				prevCommitmentData: big.NewInt(1),
 			},
 			want:    big.NewInt(1),
 			wantErr: false,

--- a/utils/block.go
+++ b/utils/block.go
@@ -54,10 +54,10 @@ func (*UtilsStruct) GetProposedBlock(client *ethclient.Client, epoch uint32, pro
 	return proposedBlock, nil
 }
 
-func (*UtilsStruct) FetchPreviousValue(client *ethclient.Client, epoch uint32, assetId uint16) (uint32, error) {
+func (*UtilsStruct) FetchPreviousValue(client *ethclient.Client, epoch uint32, assetId uint16) (*big.Int, error) {
 	block, err := UtilsInterface.GetBlock(client, epoch)
 	if err != nil {
-		return 0, err
+		return big.NewInt(0), err
 	}
 	return block.Medians[assetId-1], nil
 }

--- a/utils/block_test.go
+++ b/utils/block_test.go
@@ -26,7 +26,7 @@ func TestFetchPreviousValue(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    uint32
+		want    *big.Int
 		wantErr bool
 	}{
 		{
@@ -34,10 +34,10 @@ func TestFetchPreviousValue(t *testing.T) {
 			args: args{
 				assetId: 3,
 				block: bindings.StructsBlock{
-					Medians: []uint32{2000, 1500, 4000, 6500},
+					Medians: []*big.Int{big.NewInt(2000), big.NewInt(1500), big.NewInt(4000), big.NewInt(6500)},
 				},
 			},
-			want:    4000,
+			want:    big.NewInt(4000),
 			wantErr: false,
 		},
 		{
@@ -46,7 +46,7 @@ func TestFetchPreviousValue(t *testing.T) {
 				assetId:  3,
 				blockErr: errors.New("block error"),
 			},
-			want:    0,
+			want:    big.NewInt(0),
 			wantErr: true,
 		},
 	}
@@ -266,7 +266,7 @@ func TestGetProposedBlock(t *testing.T) {
 	var callOpts bind.CallOpts
 
 	block := bindings.StructsBlock{
-		Medians: []uint32{2000, 1500, 4000, 6500},
+		Medians: []*big.Int{big.NewInt(2000), big.NewInt(1500), big.NewInt(4000), big.NewInt(6500)},
 	}
 
 	type args struct {

--- a/utils/common.go
+++ b/utils/common.go
@@ -166,8 +166,8 @@ func (*UtilsStruct) GetRemainingTimeOfCurrentState(client *ethclient.Client, buf
 	return int64(timeRemaining - upperLimit), nil
 }
 
-func (*UtilsStruct) CalculateSalt(epoch uint32, medians []uint32) [32]byte {
-	salt := solsha3.SoliditySHA3([]string{"uint32", "uint32[]"}, []interface{}{epoch, medians})
+func (*UtilsStruct) CalculateSalt(epoch uint32, medians []*big.Int) [32]byte {
+	salt := solsha3.SoliditySHA3([]string{"uint32", "uint256"}, []interface{}{epoch, medians})
 	var saltInBytes32 [32]byte
 	copy(saltInBytes32[:], salt)
 	return saltInBytes32

--- a/utils/common_test.go
+++ b/utils/common_test.go
@@ -889,7 +889,7 @@ func TestGetRemainingTimeOfCurrentState(t *testing.T) {
 func TestCalculateSalt(t *testing.T) {
 	type args struct {
 		epoch   uint32
-		medians []uint32
+		medians []*big.Int
 	}
 	tests := []struct {
 		name string
@@ -900,9 +900,9 @@ func TestCalculateSalt(t *testing.T) {
 			name: "When CalculateSalt() is executed successfully",
 			args: args{
 				epoch:   1,
-				medians: []uint32{},
+				medians: []*big.Int{},
 			},
-			want: [32]byte{81, 248, 27, 205, 252, 50, 74, 13, 255, 43, 91, 236, 157, 146, 226, 28, 190, 188, 77, 94, 41, 211, 163, 211, 13, 227, 224, 63, 190, 171, 141, 127},
+			want: [32]byte{3, 188, 235, 65, 42, 140, 151, 61, 187, 150, 15, 19, 83, 186, 145, 207, 108, 161, 13, 253, 226, 28, 145, 16, 84, 207, 30, 97, 240, 210, 142, 11},
 		},
 	}
 	for _, tt := range tests {

--- a/utils/interface.go
+++ b/utils/interface.go
@@ -105,7 +105,7 @@ type Utils interface {
 	GetEpochLimitForUpdateCommission(client *ethclient.Client) (uint16, error)
 	GetVoteManagerWithOpts(client *ethclient.Client) (*bindings.VoteManager, bind.CallOpts)
 	GetCommitments(client *ethclient.Client, address string) ([32]byte, error)
-	GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (uint32, error)
+	GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (*big.Int, error)
 	GetInfluenceSnapshot(client *ethclient.Client, stakerId uint32, epoch uint32) (*big.Int, error)
 	GetStakeSnapshot(client *ethclient.Client, stakerId uint32, epoch uint32) (*big.Int, error)
 	GetTotalInfluenceRevealed(client *ethclient.Client, epoch uint32, medianIndex uint16) (*big.Int, error)
@@ -269,7 +269,7 @@ type AssetManagerUtils interface {
 
 type VoteManagerUtils interface {
 	Commitments(client *ethclient.Client, stakerId uint32) (types.Commitment, error)
-	GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (uint32, error)
+	GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (*big.Int, error)
 	GetInfluenceSnapshot(client *ethclient.Client, epoch uint32, stakerId uint32) (*big.Int, error)
 	GetStakeSnapshot(client *ethclient.Client, epoch uint32, stakerId uint32) (*big.Int, error)
 	GetTotalInfluenceRevealed(client *ethclient.Client, epoch uint32, medianIndex uint16) (*big.Int, error)

--- a/utils/interface.go
+++ b/utils/interface.go
@@ -84,7 +84,7 @@ type Utils interface {
 	GetOptions() bind.CallOpts
 	GetNumberOfProposedBlocks(client *ethclient.Client, epoch uint32) (uint8, error)
 	GetSortedProposedBlockId(client *ethclient.Client, epoch uint32, index *big.Int) (uint32, error)
-	FetchPreviousValue(client *ethclient.Client, epoch uint32, assetId uint16) (uint32, error)
+	FetchPreviousValue(client *ethclient.Client, epoch uint32, assetId uint16) (*big.Int, error)
 	GetBlock(client *ethclient.Client, epoch uint32) (bindings.StructsBlock, error)
 	GetMaxAltBlocks(client *ethclient.Client) (uint8, error)
 	GetMinSafeRazor(client *ethclient.Client) (*big.Int, error)
@@ -158,7 +158,7 @@ type Utils interface {
 	DeleteJobFromJSON(fileName string, jobId string) error
 	AddJobToJSON(fileName string, job *types.StructsJob) error
 	CheckTransactionReceipt(client *ethclient.Client, _txHash string) int
-	CalculateSalt(epoch uint32, medians []uint32) [32]byte
+	CalculateSalt(epoch uint32, medians []*big.Int) [32]byte
 	ToAssign(client *ethclient.Client) (uint16, error)
 	Prng(max uint32, prngHashes []byte) *big.Int
 	GetSaltFromBlockchain(client *ethclient.Client) ([32]byte, error)

--- a/utils/mocks/utils.go
+++ b/utils/mocks/utils.go
@@ -152,11 +152,11 @@ func (_m *Utils) CalculateBlockTime(client *ethclient.Client) int64 {
 }
 
 // CalculateSalt provides a mock function with given fields: epoch, medians
-func (_m *Utils) CalculateSalt(epoch uint32, medians []uint32) [32]byte {
+func (_m *Utils) CalculateSalt(epoch uint32, medians []*big.Int) [32]byte {
 	ret := _m.Called(epoch, medians)
 
 	var r0 [32]byte
-	if rf, ok := ret.Get(0).(func(uint32, []uint32) [32]byte); ok {
+	if rf, ok := ret.Get(0).(func(uint32, []*big.Int) [32]byte); ok {
 		r0 = rf(epoch, medians)
 	} else {
 		if ret.Get(0) != nil {
@@ -284,14 +284,16 @@ func (_m *Utils) FetchBalance(client *ethclient.Client, accountAddress string) (
 }
 
 // FetchPreviousValue provides a mock function with given fields: client, epoch, assetId
-func (_m *Utils) FetchPreviousValue(client *ethclient.Client, epoch uint32, assetId uint16) (uint32, error) {
+func (_m *Utils) FetchPreviousValue(client *ethclient.Client, epoch uint32, assetId uint16) (*big.Int, error) {
 	ret := _m.Called(client, epoch, assetId)
 
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint32, uint16) uint32); ok {
+	var r0 *big.Int
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint32, uint16) *big.Int); ok {
 		r0 = rf(client, epoch, assetId)
 	} else {
-		r0 = ret.Get(0).(uint32)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
 	}
 
 	var r1 error
@@ -1663,14 +1665,16 @@ func (_m *Utils) GetVoteManagerWithOpts(client *ethclient.Client) (*bindings.Vot
 }
 
 // GetVoteValue provides a mock function with given fields: client, epoch, stakerId, medianIndex
-func (_m *Utils) GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (uint32, error) {
+func (_m *Utils) GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (*big.Int, error) {
 	ret := _m.Called(client, epoch, stakerId, medianIndex)
 
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint32, uint32, uint16) uint32); ok {
+	var r0 *big.Int
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint32, uint32, uint16) *big.Int); ok {
 		r0 = rf(client, epoch, stakerId, medianIndex)
 	} else {
-		r0 = ret.Get(0).(uint32)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
 	}
 
 	var r1 error

--- a/utils/mocks/vote_manager_utils.go
+++ b/utils/mocks/vote_manager_utils.go
@@ -16,20 +16,20 @@ type VoteManagerUtils struct {
 	mock.Mock
 }
 
-// Commitments provides a mock function with given fields: _a0, _a1
-func (_m *VoteManagerUtils) Commitments(_a0 *ethclient.Client, _a1 uint32) (types.Commitment, error) {
-	ret := _m.Called(_a0, _a1)
+// Commitments provides a mock function with given fields: client, stakerId
+func (_m *VoteManagerUtils) Commitments(client *ethclient.Client, stakerId uint32) (types.Commitment, error) {
+	ret := _m.Called(client, stakerId)
 
 	var r0 types.Commitment
 	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint32) types.Commitment); ok {
-		r0 = rf(_a0, _a1)
+		r0 = rf(client, stakerId)
 	} else {
 		r0 = ret.Get(0).(types.Commitment)
 	}
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(*ethclient.Client, uint32) error); ok {
-		r1 = rf(_a0, _a1)
+		r1 = rf(client, stakerId)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -172,14 +172,16 @@ func (_m *VoteManagerUtils) GetTotalInfluenceRevealed(client *ethclient.Client, 
 }
 
 // GetVoteValue provides a mock function with given fields: client, epoch, stakerId, medianIndex
-func (_m *VoteManagerUtils) GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (uint32, error) {
+func (_m *VoteManagerUtils) GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (*big.Int, error) {
 	ret := _m.Called(client, epoch, stakerId, medianIndex)
 
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint32, uint32, uint16) uint32); ok {
+	var r0 *big.Int
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint32, uint32, uint16) *big.Int); ok {
 		r0 = rf(client, epoch, stakerId, medianIndex)
 	} else {
-		r0 = ret.Get(0).(uint32)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
 	}
 
 	var r1 error

--- a/utils/struct-utils.go
+++ b/utils/struct-utils.go
@@ -201,7 +201,7 @@ func (v VoteManagerStruct) Commitments(client *ethclient.Client, stakerId uint32
 	return voteManager.Commitments(&opts, stakerId)
 }
 
-func (v VoteManagerStruct) GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (uint32, error) {
+func (v VoteManagerStruct) GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (*big.Int, error) {
 	voteManager, opts := UtilsInterface.GetVoteManagerWithOpts(client)
 	return voteManager.GetVoteValue(&opts, epoch, stakerId, medianIndex)
 }

--- a/utils/vote.go
+++ b/utils/vote.go
@@ -40,7 +40,7 @@ func (*UtilsStruct) GetCommitments(client *ethclient.Client, address string) ([3
 	return commitments.CommitmentHash, nil
 }
 
-func (*UtilsStruct) GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (uint32, error) {
+func (*UtilsStruct) GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (*big.Int, error) {
 	var (
 		voteValue    uint32
 		voteValueErr error
@@ -55,7 +55,7 @@ func (*UtilsStruct) GetVoteValue(client *ethclient.Client, epoch uint32, stakerI
 			return nil
 		}, RetryInterface.RetryAttempts(core.MaxRetries))
 	if voteValueErr != nil {
-		return 0, voteValueErr
+		return big.NewInt(0), voteValueErr
 	}
 	return voteValue, nil
 }

--- a/utils/vote.go
+++ b/utils/vote.go
@@ -42,7 +42,7 @@ func (*UtilsStruct) GetCommitments(client *ethclient.Client, address string) ([3
 
 func (*UtilsStruct) GetVoteValue(client *ethclient.Client, epoch uint32, stakerId uint32, medianIndex uint16) (*big.Int, error) {
 	var (
-		voteValue    uint32
+		voteValue    *big.Int
 		voteValueErr error
 	)
 	voteValueErr = retry.Do(

--- a/utils/vote_test.go
+++ b/utils/vote_test.go
@@ -410,21 +410,21 @@ func TestGetVoteValue(t *testing.T) {
 	)
 
 	type args struct {
-		voteValue    uint32
+		voteValue    *big.Int
 		voteValueErr error
 	}
 	tests := []struct {
 		name    string
 		args    args
-		want    uint32
+		want    *big.Int
 		wantErr bool
 	}{
 		{
 			name: "Test 1: When GetVoteValue() executes successfully",
 			args: args{
-				voteValue: 50000,
+				voteValue: big.NewInt(50000),
 			},
-			want:    50000,
+			want:    big.NewInt(50000),
 			wantErr: false,
 		},
 		{
@@ -432,7 +432,7 @@ func TestGetVoteValue(t *testing.T) {
 			args: args{
 				voteValueErr: errors.New("voteValue error"),
 			},
-			want:    0,
+			want:    big.NewInt(0),
 			wantErr: true,
 		},
 	}
@@ -458,7 +458,7 @@ func TestGetVoteValue(t *testing.T) {
 				t.Errorf("GetVoteValue() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if got.Cmp(tt.want) != 0 {
 				t.Errorf("GetVoteValue() got = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
# Description

Medians and votes converted from uint32 to *big.Int due to latest changes in contracts for data type of votes from uint32 to uint256.

Fixes #703
