### PR TITLE
Dispute Fix

### DIFF
--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -279,7 +279,7 @@ func (*UtilsStruct) GetSortedRevealedValues(client *ethclient.Client, blockNumbe
 			if revealedValuesWithIndex[assetValue.LeafId] == nil {
 				revealedValuesWithIndex[assetValue.LeafId] = []*big.Int{assetValue.Value}
 			} else {
-				if !utils.Contains(revealedValuesWithIndex[assetValue.LeafId], assetValue.Value) {
+				if !utils.ContainsBigInteger(revealedValuesWithIndex[assetValue.LeafId], assetValue.Value) {
 					revealedValuesWithIndex[assetValue.LeafId] = append(revealedValuesWithIndex[assetValue.LeafId], assetValue.Value)
 				}
 			}

--- a/utils/array.go
+++ b/utils/array.go
@@ -36,6 +36,18 @@ func Contains(slice interface{}, val interface{}) bool {
 	return false
 }
 
+func ContainsBigInteger(arr []*big.Int, num *big.Int) bool {
+	if num == nil {
+		return false
+	}
+	for _, value := range arr {
+		if value.Cmp(num) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func IsEqual(arr1 []*big.Int, arr2 []*big.Int) (bool, int) {
 	if len(arr1) > len(arr2) {
 		return false, len(arr2)

--- a/utils/array_test.go
+++ b/utils/array_test.go
@@ -99,6 +99,42 @@ func TestContains(t *testing.T) {
 	}
 }
 
+func TestContainsBigInteger(t *testing.T) {
+	type args struct {
+		arr []*big.Int
+		num *big.Int
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Test 1: When the big integer is present in array",
+			args: args{
+				arr: []*big.Int{big.NewInt(10), big.NewInt(12), big.NewInt(7), big.NewInt(18)},
+				num: big.NewInt(7),
+			},
+			want: true,
+		},
+		{
+			name: "Test 1: When the big integer is not present in array",
+			args: args{
+				arr: []*big.Int{big.NewInt(10), big.NewInt(12), big.NewInt(7), big.NewInt(18)},
+				num: big.NewInt(8),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ContainsBigInteger(tt.args.arr, tt.args.num); got != tt.want {
+				t.Errorf("containsBigInteger() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetDataInBytes(t *testing.T) {
 	type args struct {
 		data []*big.Int


### PR DESCRIPTION
# Description
Dispute was failing as same votes were getting appended to sortedVotes array for a collection which resulted in wrong calculation of total influence revealed. Fixed that by re-correcting the check of contains to `big.int(vote)` is present in `*big.int[]votes` array.

Fixes #718

