### PR TITLE
Changed method name to resetUnstakeLock in txnopts

### DIFF
--- a/cmd/resetUnstakeLock.go
+++ b/cmd/resetUnstakeLock.go
@@ -68,7 +68,7 @@ func (*UtilsStruct) ResetUnstakeLock(client *ethclient.Client, config types.Conf
 		ChainId:         core.ChainId,
 		Config:          config,
 		ContractAddress: core.StakeManagerAddress,
-		MethodName:      "extendLock",
+		MethodName:      "resetUnstakeLock",
 		Parameters:      []interface{}{extendLockInput.StakerId},
 		ABI:             bindings.StakeManagerABI,
 	})


### PR DESCRIPTION
# Description

Changed txnOpts.MethodName from extendLock to resetUnstakeLock

Fixes #728
