### PR TITLE
BountyIds stored in a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,12 @@ $ ./razor extendLock --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --stak
 
 If you want to claim your bounty after disputing a rogue staker, you can run `claimBounty` command
 
+>**_NOTE:_**  bountyIds are stored in .razor directory with file name in format `YOUR_ADDRESS_disputeData.json file.` 
+> 
+> e.g: `0x2EDc3c6F93e4e20590F480272AB490D2620557xY_disputeData.json`
+
+If you know the bountyId, you can pass the value to `bountyId` flag.
+
 razor cli
 
 ```
@@ -465,6 +471,20 @@ Example:
 
 ```
 $ ./razor claimBounty --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --bountyId 5
+```
+
+You can also run claimBounty command without passing `bountyId` flag as it will pick up bountyIds associated to your address from the file one at a time.
+
+razor cli
+
+```
+$ ./razor claimBounty --address <address> 
+```
+
+docker
+
+```
+docker exec -it razor-go razor claimBounty --address <address> 
 ```
 
 ### Transfer

--- a/cmd/claimBounty.go
+++ b/cmd/claimBounty.go
@@ -8,9 +8,11 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"math/big"
+	"os"
 	"razor/core"
 	"razor/core/types"
 	"razor/logger"
+	"razor/path"
 	"razor/pkg/bindings"
 	"razor/utils"
 )
@@ -43,23 +45,82 @@ func (*UtilsStruct) ExecuteClaimBounty(flagSet *pflag.FlagSet) {
 
 	password := razorUtils.AssignPassword(flagSet)
 
-	bountyId, err := flagSetUtils.GetUint32BountyId(flagSet)
-	utils.CheckError("Error in getting bountyId: ", err)
-
 	client := razorUtils.ConnectToClient(config.Provider)
 
-	redeemBountyInput := types.RedeemBountyInput{
-		Address:  address,
-		Password: password,
-		BountyId: bountyId,
+	if utilsInterface.IsFlagPassed("bountyId") {
+		bountyId, err := flagSetUtils.GetUint32BountyId(flagSet)
+		utils.CheckError("Error in getting bountyId: ", err)
+
+		redeemBountyInput := types.RedeemBountyInput{
+			Address:  address,
+			Password: password,
+			BountyId: bountyId,
+		}
+
+		txn, err := cmdUtils.ClaimBounty(config, client, redeemBountyInput)
+		utils.CheckError("ClaimBounty error: ", err)
+
+		if txn != core.NilHash {
+			razorUtils.WaitForBlockCompletion(client, txn.String())
+		}
+	} else {
+		err := cmdUtils.HandleClaimBounty(client, config, types.Account{
+			Address:  address,
+			Password: password,
+		})
+		utils.CheckError("HandleClaimBounty error: ", err)
+	}
+}
+
+//This function handles claimBounty by picking bountyid's from disputeData file and if there is any error it returns the error
+func (*UtilsStruct) HandleClaimBounty(client *ethclient.Client, config types.Configurations, account types.Account) error {
+	disputeFilePath, err := razorUtils.GetDisputeDataFileName(account.Address)
+	if err != nil {
+		return err
 	}
 
-	txn, err := cmdUtils.ClaimBounty(config, client, redeemBountyInput)
-	utils.CheckError("ClaimBounty error: ", err)
-
-	if txn != core.NilHash {
-		razorUtils.WaitForBlockCompletion(client, txn.String())
+	if _, err := path.OSUtilsInterface.Stat(disputeFilePath); !errors.Is(err, os.ErrNotExist) {
+		disputeData, err = razorUtils.ReadFromDisputeJsonFile(disputeFilePath)
+		if err != nil {
+			return err
+		}
 	}
+
+	if disputeData.BountyIdQueue == nil {
+		log.Error("No bounty id's present")
+		return errors.New("no bounty earned")
+	}
+
+	if disputeData.BountyIdQueue != nil {
+		log.Info("Bounty ids that needs be claimed: ", disputeData.BountyIdQueue)
+		length := len(disputeData.BountyIdQueue)
+		log.Info("Claiming bounty for bountyId ", disputeData.BountyIdQueue[length-1])
+		claimBountyTxn, err := cmdUtils.ClaimBounty(config, client, types.RedeemBountyInput{
+			BountyId: disputeData.BountyIdQueue[length-1],
+			Address:  account.Address,
+			Password: account.Password,
+		})
+		if err != nil {
+			return err
+		}
+		if claimBountyTxn != core.NilHash {
+			claimBountyStatus := utilsInterface.WaitForBlockCompletion(client, claimBountyTxn.String())
+			if claimBountyStatus == 1 {
+				if len(disputeData.BountyIdQueue) > 1 {
+					//Removing the bountyId from the queue as the bounty is being claimed
+					disputeData.BountyIdQueue = disputeData.BountyIdQueue[:length-1]
+				} else {
+					disputeData.BountyIdQueue = nil
+				}
+			}
+		}
+	}
+
+	err = razorUtils.SaveDataToDisputeJsonFile(disputeFilePath, disputeData.BountyIdQueue)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 //This function allows the users who are bountyHunter to redeem their bounty in razor network
@@ -131,7 +192,5 @@ func init() {
 
 	addrErr := claimBountyCmd.MarkFlagRequired("address")
 	utils.CheckError("Address error: ", addrErr)
-	bountyIdErr := claimBountyCmd.MarkFlagRequired("bountyId")
-	utils.CheckError("BountyId error: ", bountyIdErr)
 
 }

--- a/cmd/claimBounty_test.go
+++ b/cmd/claimBounty_test.go
@@ -11,10 +11,15 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/mock"
+	"io/fs"
 	"math/big"
 	"razor/cmd/mocks"
 	"razor/core"
 	"razor/core/types"
+	"razor/path"
+	pathMocks "razor/path/mocks"
+	"razor/utils"
+	mocks2 "razor/utils/mocks"
 	"testing"
 )
 
@@ -23,15 +28,17 @@ func TestExecuteClaimBounty(t *testing.T) {
 	var flagSet *pflag.FlagSet
 
 	type args struct {
-		config         types.Configurations
-		configErr      error
-		password       string
-		address        string
-		addressErr     error
-		bountyId       uint32
-		bountyIdErr    error
-		claimBountyTxn common.Hash
-		claimBountyErr error
+		config               types.Configurations
+		configErr            error
+		password             string
+		address              string
+		addressErr           error
+		isFlagPassed         bool
+		bountyId             uint32
+		bountyIdErr          error
+		claimBountyTxn       common.Hash
+		claimBountyErr       error
+		handleClaimBountyErr error
 	}
 	tests := []struct {
 		name          string
@@ -45,6 +52,7 @@ func TestExecuteClaimBounty(t *testing.T) {
 				password:       "test",
 				address:        "0x000000000000000000000000000000000000dead",
 				bountyId:       2,
+				isFlagPassed:   true,
 				claimBountyTxn: common.BigToHash(big.NewInt(1)),
 			},
 			expectedFatal: false,
@@ -77,6 +85,7 @@ func TestExecuteClaimBounty(t *testing.T) {
 				config:         types.Configurations{},
 				password:       "test",
 				address:        "0x000000000000000000000000000000000000dead",
+				isFlagPassed:   true,
 				bountyIdErr:    errors.New("bountyId error"),
 				claimBountyTxn: common.BigToHash(big.NewInt(1)),
 			},
@@ -88,8 +97,21 @@ func TestExecuteClaimBounty(t *testing.T) {
 				config:         types.Configurations{},
 				password:       "test",
 				address:        "0x000000000000000000000000000000000000dead",
+				isFlagPassed:   true,
 				bountyId:       2,
 				claimBountyErr: errors.New("claimBounty error"),
+			},
+			expectedFatal: true,
+		},
+		{
+			name: "Test 6: When there is an error from HandleClaimBounty function",
+			args: args{
+				config:               types.Configurations{},
+				password:             "test",
+				address:              "0x000000000000000000000000000000000000dead",
+				isFlagPassed:         false,
+				bountyId:             2,
+				handleClaimBountyErr: errors.New("HandleClaimBounty error"),
 			},
 			expectedFatal: true,
 		},
@@ -105,10 +127,12 @@ func TestExecuteClaimBounty(t *testing.T) {
 			utilsMock := new(mocks.UtilsInterface)
 			flagSetUtilsMock := new(mocks.FlagSetInterface)
 			cmdUtilsMock := new(mocks.UtilsCmdInterface)
+			utilsPkgMock := new(mocks2.Utils)
 
 			razorUtils = utilsMock
 			flagSetUtils = flagSetUtilsMock
 			cmdUtils = cmdUtilsMock
+			utilsInterface = utilsPkgMock
 
 			utilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"))
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
@@ -116,6 +140,8 @@ func TestExecuteClaimBounty(t *testing.T) {
 			flagSetUtilsMock.On("GetStringAddress", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.address, tt.args.addressErr)
 			flagSetUtilsMock.On("GetUint32BountyId", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.bountyId, tt.args.bountyIdErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
+			utilsPkgMock.On("IsFlagPassed", mock.Anything).Return(tt.args.isFlagPassed)
+			cmdUtilsMock.On("HandleClaimBounty", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.handleClaimBountyErr)
 			cmdUtilsMock.On("ClaimBounty", mock.Anything, mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(tt.args.claimBountyTxn, tt.args.claimBountyErr)
 			utilsMock.On("WaitForBlockCompletion", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string")).Return(1)
 
@@ -275,6 +301,120 @@ func TestClaimBounty(t *testing.T) {
 				if err.Error() != tt.wantErr.Error() {
 					t.Errorf("Error for claimBounty function, got = %v, want = %v", err, tt.wantErr)
 				}
+			}
+		})
+	}
+}
+
+func TestHandleClaimBounty(t *testing.T) {
+	var (
+		client   *ethclient.Client
+		config   types.Configurations
+		account  types.Account
+		fileInfo fs.FileInfo
+	)
+	type args struct {
+		disputeFilePath    string
+		disputeFilePathErr error
+		statErr            error
+		disputeData        types.DisputeFileData
+		disputeDataErr     error
+		claimBountyTxn     common.Hash
+		claimBountyTxnErr  error
+		claimBountyStatus  int
+		saveDataErr        error
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Test 1: When HandleClaimBounty() executes successfully",
+			args: args{
+				disputeFilePath:   "",
+				statErr:           nil,
+				disputeData:       types.DisputeFileData{BountyIdQueue: []uint32{1}},
+				claimBountyTxn:    common.BigToHash(big.NewInt(1)),
+				claimBountyStatus: 1,
+				saveDataErr:       nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test 2: When HandleClaimBounty() executes successfully and there are more than one bountyId in queue",
+			args: args{
+				disputeFilePath:   "",
+				statErr:           nil,
+				disputeData:       types.DisputeFileData{BountyIdQueue: []uint32{1, 2}},
+				claimBountyTxn:    common.BigToHash(big.NewInt(1)),
+				claimBountyStatus: 1,
+				saveDataErr:       nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test 3: When there is an error in getting disputeFilePath",
+			args: args{
+				disputeFilePathErr: errors.New("error in getting disputeFilePath"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Test 6: When there is an error in getting disputeData",
+			args: args{
+				disputeFilePath: "",
+				statErr:         nil,
+				disputeDataErr:  errors.New("error in getting diapute data"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "When there is an error in claimBounty",
+			args: args{
+				disputeFilePath:   "",
+				statErr:           nil,
+				disputeData:       types.DisputeFileData{BountyIdQueue: []uint32{1}},
+				claimBountyTxnErr: errors.New("error in claimBounty"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "When there is an error in saving data to file",
+			args: args{
+				disputeFilePath:   "",
+				statErr:           nil,
+				disputeData:       types.DisputeFileData{BountyIdQueue: []uint32{1}},
+				claimBountyTxn:    common.BigToHash(big.NewInt(1)),
+				claimBountyStatus: 1,
+				saveDataErr:       errors.New("error in saving data to file"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			utilsMock := new(mocks.UtilsInterface)
+			cmdUtilsMock := new(mocks.UtilsCmdInterface)
+			utilsPkgMock := new(mocks2.Utils)
+			osUtilsMock := new(pathMocks.OSInterface)
+
+			razorUtils = utilsMock
+			cmdUtils = cmdUtilsMock
+			utils.UtilsInterface = utilsPkgMock
+			utilsInterface = utilsPkgMock
+			path.OSUtilsInterface = osUtilsMock
+
+			utilsMock.On("GetDisputeDataFileName", mock.AnythingOfType("string")).Return(tt.args.disputeFilePath, tt.args.disputeFilePathErr)
+			osUtilsMock.On("Stat", mock.Anything).Return(fileInfo, tt.args.statErr)
+			utilsMock.On("ReadFromDisputeJsonFile", mock.Anything).Return(tt.args.disputeData, tt.args.disputeDataErr)
+			cmdUtilsMock.On("ClaimBounty", mock.Anything, mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(tt.args.claimBountyTxn, tt.args.claimBountyTxnErr)
+			utilsPkgMock.On("WaitForBlockCompletion", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string")).Return(tt.args.claimBountyStatus)
+			utilsMock.On("SaveDataToDisputeJsonFile", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.saveDataErr)
+
+			ut := &UtilsStruct{}
+			if err := ut.HandleClaimBounty(client, config, account); (err != nil) != tt.wantErr {
+				t.Errorf("AutoClaimBounty() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/cmd/dispute.go
+++ b/cmd/dispute.go
@@ -12,8 +12,10 @@ import (
 	solsha3 "github.com/miguelmota/go-solidity-sha3"
 	"math/big"
 	"math/rand"
+	"os"
 	"razor/core"
 	"razor/core/types"
+	"razor/path"
 	"razor/pkg/bindings"
 	"razor/utils"
 	"strings"
@@ -21,14 +23,12 @@ import (
 
 var (
 	giveSortedLeafIds []int
-	disputedFlag      bool
 )
 
 //blockId is id of the block
 
 //This function handles the dispute and if there is any error it returns the error
 func (*UtilsStruct) HandleDispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) error {
-	disputedFlag = false
 
 	sortedProposedBlockIds, err := razorUtils.GetSortedProposedBlockIds(client, epoch)
 	if err != nil {
@@ -87,8 +87,14 @@ func (*UtilsStruct) HandleDispute(client *ethclient.Client, config types.Configu
 			}
 			log.Info("Txn Hash: ", transactionUtils.Hash(disputeBiggestStakeProposedTxn))
 			status := razorUtils.WaitForBlockCompletion(client, transactionUtils.Hash(disputeBiggestStakeProposedTxn).String())
+
+			//If dispute happens, then storing the bountyId into disputeData file
 			if status == 1 {
-				disputedFlag = true
+				err = cmdUtils.StoreBountyId(client, account)
+				if err != nil {
+					log.Error(err)
+					break
+				}
 				continue
 			}
 		}
@@ -104,8 +110,14 @@ func (*UtilsStruct) HandleDispute(client *ethclient.Client, config types.Configu
 		if idDisputeTxn != nil {
 			log.Debugf("Txn Hash: %s", transactionUtils.Hash(idDisputeTxn).String())
 			status := razorUtils.WaitForBlockCompletion(client, transactionUtils.Hash(idDisputeTxn).String())
+
+			//If dispute happens, then storing the bountyId into disputeData file
 			if status == 1 {
-				disputedFlag = true
+				err = cmdUtils.StoreBountyId(client, account)
+				if err != nil {
+					log.Error(err)
+					break
+				}
 				continue
 			}
 		}
@@ -283,8 +295,13 @@ func (*UtilsStruct) Dispute(client *ethclient.Client, config types.Configuration
 	}
 	log.Info("Txn Hash: ", transactionUtils.Hash(finalizeTxn))
 	status := razorUtils.WaitForBlockCompletion(client, transactionUtils.Hash(finalizeTxn).String())
+
+	//If dispute happens, then storing the bountyId into disputeData file
 	if status == 1 {
-		disputedFlag = true
+		err = cmdUtils.StoreBountyId(client, account)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -362,4 +379,44 @@ func (*UtilsStruct) GetBountyIdFromEvents(client *ethclient.Client, blockNumber 
 		}
 	}
 	return bountyId, nil
+}
+
+//This function saves the bountyId in disputeData file and return the error if there is any
+func (*UtilsStruct) StoreBountyId(client *ethclient.Client, account types.Account) error {
+	disputeFilePath, err := razorUtils.GetDisputeDataFileName(account.Address)
+	if err != nil {
+		return err
+	}
+
+	var latestBountyId uint32
+
+	latestHeader, err := utils.UtilsInterface.GetLatestBlockWithRetry(client)
+	if err != nil {
+		log.Error("Error in fetching block: ", err)
+		return err
+	}
+
+	latestBountyId, err = cmdUtils.GetBountyIdFromEvents(client, latestHeader.Number, account.Address)
+	if err != nil {
+		return err
+	}
+
+	if _, err := path.OSUtilsInterface.Stat(disputeFilePath); !errors.Is(err, os.ErrNotExist) {
+		disputeData, err = razorUtils.ReadFromDisputeJsonFile(disputeFilePath)
+		if err != nil {
+			return err
+		}
+	}
+
+	if latestBountyId != 0 {
+		//prepending the latestBountyId to the queue
+		disputeData.BountyIdQueue = append([]uint32{latestBountyId}, disputeData.BountyIdQueue...)
+	}
+
+	//saving the updated bountyIds to disputeData file
+	err = razorUtils.SaveDataToDisputeJsonFile(disputeFilePath, disputeData.BountyIdQueue)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/cmd/dispute_test.go
+++ b/cmd/dispute_test.go
@@ -12,9 +12,12 @@ import (
 	Types "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/mock"
+	"io/fs"
 	"math/big"
 	"razor/cmd/mocks"
 	"razor/core/types"
+	"razor/path"
+	pathMocks "razor/path/mocks"
 	"razor/pkg/bindings"
 	"razor/utils"
 	mocks2 "razor/utils/mocks"
@@ -44,6 +47,7 @@ func TestDispute(t *testing.T) {
 		finalizeDisputeTxn          *Types.Transaction
 		finalizeDisputeErr          error
 		hash                        common.Hash
+		storeBountyIdErr            error
 	}
 	tests := []struct {
 		name string
@@ -76,6 +80,16 @@ func TestDispute(t *testing.T) {
 			},
 			want: errors.New("finalizeDispute error"),
 		},
+		{
+			name: "Test 4: When Dispute function executes successfully but there is an error in storing bountyId",
+			args: args{
+				containsStatus:     false,
+				finalizeDisputeTxn: &Types.Transaction{},
+				hash:               common.BigToHash(big.NewInt(1)),
+				storeBountyIdErr:   errors.New("storeBountyId error"),
+			},
+			want: errors.New("storeBountyId error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -96,6 +110,7 @@ func TestDispute(t *testing.T) {
 			cmdUtilsMock.On("GetCollectionIdPositionInBlock", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.positionOfCollectionInBlock)
 			blockManagerUtilsMock.On("FinalizeDispute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.finalizeDisputeTxn, tt.args.finalizeDisputeErr)
 			transactionUtilsMock.On("Hash", mock.Anything).Return(tt.args.hash)
+			cmdUtilsMock.On("StoreBountyId", mock.Anything, mock.Anything).Return(tt.args.storeBountyIdErr)
 			utilsMock.On("WaitForBlockCompletion", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string")).Return(1)
 
 			utils := &UtilsStruct{}
@@ -143,11 +158,11 @@ func TestHandleDispute(t *testing.T) {
 		idDisputeTxn              *Types.Transaction
 		idDisputeTxnErr           error
 		status                    int
-		isEqual                   bool
 		misMatchIndex             int
 		leafId                    uint16
 		leafIdErr                 error
 		disputeErr                error
+		storeBountyIdErr          error
 	}
 	tests := []struct {
 		name string
@@ -172,7 +187,6 @@ func TestHandleDispute(t *testing.T) {
 					Valid:        true,
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				},
-				isEqual:    true,
 				disputeErr: nil,
 			},
 			want: nil,
@@ -187,7 +201,6 @@ func TestHandleDispute(t *testing.T) {
 					Medians:      []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				},
-				isEqual:    true,
 				disputeErr: nil,
 			},
 			want: nil,
@@ -199,7 +212,6 @@ func TestHandleDispute(t *testing.T) {
 				proposedBlock: bindings.StructsBlock{
 					Medians: []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 				},
-				isEqual:    true,
 				disputeErr: nil,
 			},
 			want: errors.New("sortedProposedBlockIds error"),
@@ -209,7 +221,6 @@ func TestHandleDispute(t *testing.T) {
 			args: args{
 				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
 				proposedBlockErr:       errors.New("proposedBlock error"),
-				isEqual:                true,
 				disputeErr:             nil,
 			},
 			want: nil,
@@ -224,7 +235,6 @@ func TestHandleDispute(t *testing.T) {
 					Medians:      []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				},
-				isEqual: false,
 			},
 			want: nil,
 		},
@@ -241,7 +251,6 @@ func TestHandleDispute(t *testing.T) {
 				},
 				disputeBiggestStakeTxn: &Types.Transaction{},
 				Hash:                   common.BigToHash(big.NewInt(1)),
-				isEqual:                false,
 				disputeErr:             nil,
 				status:                 1,
 			},
@@ -259,7 +268,6 @@ func TestHandleDispute(t *testing.T) {
 				},
 				disputeBiggestStakeTxn: &Types.Transaction{},
 				Hash:                   common.BigToHash(big.NewInt(1)),
-				isEqual:                false,
 				disputeErr:             nil,
 			},
 			want: errors.New("biggestInfluenceAndIdErr"),
@@ -278,7 +286,6 @@ func TestHandleDispute(t *testing.T) {
 				},
 				disputeBiggestStakeErr: errors.New("disputeBiggestStake error"),
 				Hash:                   common.BigToHash(big.NewInt(1)),
-				isEqual:                false,
 				disputeErr:             nil,
 			},
 			want: nil,
@@ -312,7 +319,6 @@ func TestHandleDispute(t *testing.T) {
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				},
 				idDisputeTxnErr: errors.New("error in fetching Ids from CheckDisputeForIds"),
-				isEqual:         true,
 				disputeErr:      nil,
 			},
 			want: nil,
@@ -337,7 +343,6 @@ func TestHandleDispute(t *testing.T) {
 				},
 				idDisputeTxn: &Types.Transaction{},
 				status:       1,
-				isEqual:      false,
 				disputeErr:   nil,
 			},
 			want: nil,
@@ -361,7 +366,6 @@ func TestHandleDispute(t *testing.T) {
 					Valid:        true,
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				},
-				isEqual:       false,
 				misMatchIndex: 0,
 				leafIdErr:     errors.New("error in getting leafId"),
 				disputeErr:    nil,
@@ -387,10 +391,53 @@ func TestHandleDispute(t *testing.T) {
 					Valid:        true,
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				},
-				isEqual:       false,
 				misMatchIndex: 0,
 				leafId:        1,
 				disputeErr:    errors.New("error in dispute"),
+			},
+			want: nil,
+		},
+		{
+			name: "Test 14: When there is a biggest influence dispute case but there is an error in storing bountyId",
+			args: args{
+				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
+				biggestStakeId:         2,
+				proposedBlock: bindings.StructsBlock{
+					Medians:      []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
+					Valid:        true,
+					BiggestStake: big.NewInt(1).Mul(big.NewInt(4356), big.NewInt(1e18)),
+				},
+				disputeBiggestStakeTxn: &Types.Transaction{},
+				Hash:                   common.BigToHash(big.NewInt(1)),
+				disputeErr:             nil,
+				status:                 1,
+				storeBountyIdErr:       errors.New("storeBountyId error"),
+			},
+			want: nil,
+		},
+		{
+			name: "Test 15: When there is a idsDispute case but there is an error in storing bountyId",
+			args: args{
+				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
+				biggestStakeId:         2,
+				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
+				revealedCollectionIds:  []uint16{1},
+				revealedDataMaps: &types.RevealedDataMaps{
+					SortedRevealedValues: nil,
+					VoteWeights:          nil,
+					InfluenceSum:         nil,
+				},
+				proposedBlock: bindings.StructsBlock{
+					Medians:      []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
+					Valid:        true,
+					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
+				},
+				idDisputeTxn:     &Types.Transaction{},
+				status:           1,
+				storeBountyIdErr: errors.New("storeBountyId error"),
+				disputeErr:       nil,
 			},
 			want: nil,
 		},
@@ -421,9 +468,9 @@ func TestHandleDispute(t *testing.T) {
 			transactionUtilsMock.On("Hash", mock.Anything).Return(tt.args.Hash)
 			utilsMock.On("WaitForBlockCompletion", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string")).Return(tt.args.status)
 			cmdUtilsMock.On("CheckDisputeForIds", mock.AnythingOfType("*ethclient.Client"), mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.idDisputeTxn, tt.args.idDisputeTxnErr)
-			utilsPkgMock.On("IsEqualUint32", mock.Anything, mock.Anything).Return(tt.args.isEqual, tt.args.misMatchIndex)
 			utilsPkgMock.On("GetLeafIdOfACollection", mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(tt.args.leafId, tt.args.leafIdErr)
 			cmdUtilsMock.On("Dispute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.disputeErr)
+			cmdUtilsMock.On("StoreBountyId", mock.Anything, mock.Anything).Return(tt.args.storeBountyIdErr)
 
 			utils := &UtilsStruct{}
 			err := utils.HandleDispute(client, config, account, epoch, blockNumber, rogueData)
@@ -1002,9 +1049,9 @@ func BenchmarkHandleDispute(b *testing.B) {
 				transactionUtilsMock.On("Hash", mock.Anything).Return(common.BigToHash(big.NewInt(1)))
 				utilsMock.On("WaitForBlockCompletion", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string")).Return(1)
 				cmdUtilsMock.On("CheckDisputeForIds", mock.AnythingOfType("*ethclient.Client"), mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&Types.Transaction{}, nil)
-				utilsPkgMock.On("IsEqualUint32", mock.Anything, mock.Anything).Return(true, 0)
 				utilsPkgMock.On("GetLeafIdOfACollection", mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(0, nil)
 				cmdUtilsMock.On("Dispute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				cmdUtilsMock.On("StoreBountyId", mock.Anything, mock.Anything).Return(nil)
 
 				utils := &UtilsStruct{}
 				err := utils.HandleDispute(client, config, account, epoch, blockNumber, rogueData)
@@ -1031,4 +1078,134 @@ func getUint32DummyIds(numOfIds uint32) []uint32 {
 		result = append(result, i)
 	}
 	return result
+}
+
+func TestStoreBountyId(t *testing.T) {
+	var (
+		client   *ethclient.Client
+		account  types.Account
+		fileInfo fs.FileInfo
+	)
+	type args struct {
+		disputeFilePath    string
+		disputeFilePathErr error
+		disputedFlag       bool
+		latestHeader       *Types.Header
+		latestHeaderErr    error
+		latestBountyId     uint32
+		latestBountyIdErr  error
+		statErr            error
+		disputeData        types.DisputeFileData
+		disputeDataErr     error
+		saveDataErr        error
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Test 1: When StoreBountyId() executes successfully",
+			args: args{
+				disputeFilePath: "",
+				disputedFlag:    true,
+				latestHeader:    &Types.Header{Number: big.NewInt(1)},
+				latestBountyId:  1,
+				statErr:         nil,
+				disputeData:     types.DisputeFileData{BountyIdQueue: []uint32{1}},
+				saveDataErr:     nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test 2: When StoreBountyId() executes successfully and there are more than one bountyId in queue",
+			args: args{
+				disputeFilePath: "",
+				disputedFlag:    true,
+				latestHeader:    &Types.Header{Number: big.NewInt(1)},
+				latestBountyId:  1,
+				statErr:         nil,
+				disputeData:     types.DisputeFileData{BountyIdQueue: []uint32{1, 2}},
+				saveDataErr:     nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test 3: When there is an error in getting disputeFilePath",
+			args: args{
+				disputeFilePathErr: errors.New("error in getting disputeFilePath"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Test 4: When there is an error in getting latest header",
+			args: args{
+				disputeFilePath: "",
+				disputedFlag:    true,
+				latestHeaderErr: errors.New("error in getting latest header"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Test 5: When there is an error in not getting latest bountyId",
+			args: args{
+				disputeFilePath:   "",
+				disputedFlag:      true,
+				latestHeader:      &Types.Header{Number: big.NewInt(1)},
+				latestBountyIdErr: errors.New("error in getting latest bountyId"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Test 6: When there is an error in getting disputeData",
+			args: args{
+				disputeFilePath: "",
+				disputedFlag:    true,
+				latestHeader:    &Types.Header{Number: big.NewInt(1)},
+				latestBountyId:  1,
+				statErr:         nil,
+				disputeDataErr:  errors.New("error in getting diapute data"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "When there is an error in saving data to file",
+			args: args{
+				disputeFilePath: "",
+				disputedFlag:    true,
+				latestHeader:    &Types.Header{Number: big.NewInt(1)},
+				latestBountyId:  1,
+				statErr:         nil,
+				disputeData:     types.DisputeFileData{BountyIdQueue: []uint32{1}},
+				saveDataErr:     errors.New("error in saving data to file"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			utilsMock := new(mocks.UtilsInterface)
+			cmdUtilsMock := new(mocks.UtilsCmdInterface)
+			utilsPkgMock := new(mocks2.Utils)
+			osUtilsMock := new(pathMocks.OSInterface)
+
+			razorUtils = utilsMock
+			cmdUtils = cmdUtilsMock
+			utils.UtilsInterface = utilsPkgMock
+			utilsInterface = utilsPkgMock
+			path.OSUtilsInterface = osUtilsMock
+
+			utilsMock.On("GetDisputeDataFileName", mock.AnythingOfType("string")).Return(tt.args.disputeFilePath, tt.args.disputeFilePathErr)
+			utilsPkgMock.On("GetLatestBlockWithRetry", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.latestHeader, tt.args.latestHeaderErr)
+			cmdUtilsMock.On("GetBountyIdFromEvents", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.latestBountyId, tt.args.latestBountyIdErr)
+			osUtilsMock.On("Stat", mock.Anything).Return(fileInfo, tt.args.statErr)
+			utilsMock.On("ReadFromDisputeJsonFile", mock.Anything).Return(tt.args.disputeData, tt.args.disputeDataErr)
+			utilsMock.On("SaveDataToDisputeJsonFile", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.saveDataErr)
+
+			ut := &UtilsStruct{}
+			if err := ut.StoreBountyId(client, account); (err != nil) != tt.wantErr {
+				t.Errorf("AutoClaimBounty() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
 }

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -321,9 +321,10 @@ type UtilsCmdInterface interface {
 	InitiateReveal(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, staker bindings.StructsStaker, rogueData types.Rogue) error
 	InitiatePropose(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, staker bindings.StructsStaker, blockNumber *big.Int, rogueData types.Rogue) error
 	GetBountyIdFromEvents(client *ethclient.Client, blockNumber *big.Int, bountyHunter string) (uint32, error)
-	AutoClaimBounty(client *ethclient.Client, config types.Configurations, account types.Account) error
+	HandleClaimBounty(client *ethclient.Client, config types.Configurations, account types.Account) error
 	ExecuteContractAddresses(flagSet *pflag.FlagSet)
 	ContractAddresses()
+	StoreBountyId(client *ethclient.Client, account types.Account) error
 }
 
 type TransactionInterface interface {

--- a/cmd/mocks/utils_cmd_interface.go
+++ b/cmd/mocks/utils_cmd_interface.go
@@ -100,20 +100,6 @@ func (_m *UtilsCmdInterface) AssignAmountInWei(flagSet *pflag.FlagSet) (*big.Int
 	return r0, r1
 }
 
-// AutoClaimBounty provides a mock function with given fields: client, config, account
-func (_m *UtilsCmdInterface) AutoClaimBounty(client *ethclient.Client, config types.Configurations, account types.Account) error {
-	ret := _m.Called(client, config, account)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account) error); ok {
-		r0 = rf(client, config, account)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // AutoUnstakeAndWithdraw provides a mock function with given fields: client, account, amount, config
 func (_m *UtilsCmdInterface) AutoUnstakeAndWithdraw(client *ethclient.Client, account types.Account, amount *big.Int, config types.Configurations) {
 	_m.Called(client, account, amount, config)
@@ -949,6 +935,20 @@ func (_m *UtilsCmdInterface) HandleBlock(client *ethclient.Client, account types
 	_m.Called(client, account, blockNumber, config, rogueData)
 }
 
+// HandleClaimBounty provides a mock function with given fields: client, config, account
+func (_m *UtilsCmdInterface) HandleClaimBounty(client *ethclient.Client, config types.Configurations, account types.Account) error {
+	ret := _m.Called(client, config, account)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account) error); ok {
+		r0 = rf(client, config, account)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // HandleCommitState provides a mock function with given fields: client, epoch, seed, rogueData
 func (_m *UtilsCmdInterface) HandleCommitState(client *ethclient.Client, epoch uint32, seed []byte, rogueData types.Rogue) (types.CommitData, error) {
 	ret := _m.Called(client, epoch, seed, rogueData)
@@ -1402,6 +1402,20 @@ func (_m *UtilsCmdInterface) StakeCoins(txnArgs types.TransactionOptions) (commo
 	}
 
 	return r0, r1
+}
+
+// StoreBountyId provides a mock function with given fields: client, account
+func (_m *UtilsCmdInterface) StoreBountyId(client *ethclient.Client, account types.Account) error {
+	ret := _m.Called(client, account)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Account) error); ok {
+		r0 = rf(client, account)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // Transfer provides a mock function with given fields: client, config, transferInput

--- a/cmd/mocks/utils_interface.go
+++ b/cmd/mocks/utils_interface.go
@@ -143,22 +143,6 @@ func (_m *UtilsInterface) ConnectToClient(provider string) *ethclient.Client {
 	return r0
 }
 
-// ConvertBigIntArrayToUint32Array provides a mock function with given fields: bigIntArray
-func (_m *UtilsInterface) ConvertBigIntArrayToUint32Array(bigIntArray []*big.Int) []uint32 {
-	ret := _m.Called(bigIntArray)
-
-	var r0 []uint32
-	if rf, ok := ret.Get(0).(func([]*big.Int) []uint32); ok {
-		r0 = rf(bigIntArray)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]uint32)
-		}
-	}
-
-	return r0
-}
-
 // ConvertRZRToSRZR provides a mock function with given fields: sAmount, currentStake, totalSupply
 func (_m *UtilsInterface) ConvertRZRToSRZR(sAmount *big.Int, currentStake *big.Int, totalSupply *big.Int) (*big.Int, error) {
 	ret := _m.Called(sAmount, currentStake, totalSupply)

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -13,7 +13,6 @@ import (
 	"razor/core"
 	"razor/core/types"
 	"razor/logger"
-	"razor/path"
 	"razor/pkg/bindings"
 	"razor/utils"
 	"strings"
@@ -248,7 +247,7 @@ func (*UtilsStruct) HandleBlock(client *ethclient.Client, account types.Account,
 		lastVerification = epoch
 
 		if utilsInterface.IsFlagPassed("autoClaimBounty") {
-			err = cmdUtils.AutoClaimBounty(client, config, account)
+			err = cmdUtils.HandleClaimBounty(client, config, account)
 			if err != nil {
 				log.Error(err)
 				break
@@ -428,69 +427,6 @@ func (*UtilsStruct) InitiatePropose(client *ethclient.Client, config types.Confi
 	}
 	if proposeTxn != core.NilHash {
 		razorUtils.WaitForBlockCompletion(client, proposeTxn.String())
-	}
-	return nil
-}
-
-//This function helps the staker to claim the bounty automatically
-func (*UtilsStruct) AutoClaimBounty(client *ethclient.Client, config types.Configurations, account types.Account) error {
-	disputeFilePath, err := razorUtils.GetDisputeDataFileName(account.Address)
-	if err != nil {
-		return err
-	}
-
-	var latestBountyId uint32
-
-	//Checking if dispute happens, if yes than getting the bountyId from events
-	if disputedFlag {
-		latestHeader, err := utils.UtilsInterface.GetLatestBlockWithRetry(client)
-		if err != nil {
-			log.Error("Error in fetching block: ", err)
-			return err
-		}
-
-		latestBountyId, err = cmdUtils.GetBountyIdFromEvents(client, latestHeader.Number, account.Address)
-		if err != nil {
-			return err
-		}
-	}
-
-	if _, err := path.OSUtilsInterface.Stat(disputeFilePath); !errors.Is(err, os.ErrNotExist) {
-		disputeData, err = razorUtils.ReadFromDisputeJsonFile(disputeFilePath)
-		if err != nil {
-			return err
-		}
-	}
-	if disputeData.BountyIdQueue != nil {
-		length := len(disputeData.BountyIdQueue)
-		claimBountyTxn, err := cmdUtils.ClaimBounty(config, client, types.RedeemBountyInput{
-			BountyId: disputeData.BountyIdQueue[length-1],
-			Address:  account.Address,
-			Password: account.Password,
-		})
-		if err != nil {
-			return err
-		}
-		if claimBountyTxn != core.NilHash {
-			claimBountyStatus := utilsInterface.WaitForBlockCompletion(client, claimBountyTxn.String())
-			if claimBountyStatus == 1 {
-				if len(disputeData.BountyIdQueue) > 1 {
-					//Removing the bountyId from the queue as the bounty is being claimed
-					disputeData.BountyIdQueue = disputeData.BountyIdQueue[:length-1]
-				} else {
-					disputeData.BountyIdQueue = nil
-				}
-			}
-		}
-	}
-
-	if latestBountyId != 0 {
-		//prepending the latestBountyId to the queue
-		disputeData.BountyIdQueue = append([]uint32{latestBountyId}, disputeData.BountyIdQueue...)
-	}
-	err = razorUtils.SaveDataToDisputeJsonFile(disputeFilePath, disputeData.BountyIdQueue)
-	if err != nil {
-		return err
 	}
 	return nil
 }

--- a/cmd/vote_test.go
+++ b/cmd/vote_test.go
@@ -10,14 +10,11 @@ import (
 	solsha3 "github.com/miguelmota/go-solidity-sha3"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/mock"
-	"io/fs"
 	"math/big"
 	"razor/accounts"
 	accountMocks "razor/accounts/mocks"
 	"razor/cmd/mocks"
 	"razor/core/types"
-	"razor/path"
-	pathMocks "razor/path/mocks"
 	"razor/pkg/bindings"
 	"razor/utils"
 	mocks2 "razor/utils/mocks"
@@ -944,35 +941,35 @@ func TestHandleBlock(t *testing.T) {
 	)
 
 	type args struct {
-		config              types.Configurations
-		state               int64
-		stateErr            error
-		epoch               uint32
-		epochErr            error
-		stateName           string
-		stakerId            uint32
-		stakerIdErr         error
-		staker              bindings.StructsStaker
-		stakerErr           error
-		ethBalance          *big.Int
-		ethBalanceErr       error
-		minStakeAmount      *big.Int
-		minStakeAmountErr   error
-		actualStake         *big.Float
-		actualStakeErr      error
-		actualBalance       *big.Float
-		sRZRBalance         *big.Int
-		sRZRBalanceErr      error
-		sRZRInEth           *big.Float
-		initiateCommitErr   error
-		initiateRevealErr   error
-		initiateProposeErr  error
-		handleDisputeErr    error
-		claimBlockRewardTxn common.Hash
-		claimBlockRewardErr error
-		lastVerification    uint32
-		isFlagPassed        bool
-		autoClaimBountyErr  error
+		config               types.Configurations
+		state                int64
+		stateErr             error
+		epoch                uint32
+		epochErr             error
+		stateName            string
+		stakerId             uint32
+		stakerIdErr          error
+		staker               bindings.StructsStaker
+		stakerErr            error
+		ethBalance           *big.Int
+		ethBalanceErr        error
+		minStakeAmount       *big.Int
+		minStakeAmountErr    error
+		actualStake          *big.Float
+		actualStakeErr       error
+		actualBalance        *big.Float
+		sRZRBalance          *big.Int
+		sRZRBalanceErr       error
+		sRZRInEth            *big.Float
+		initiateCommitErr    error
+		initiateRevealErr    error
+		initiateProposeErr   error
+		handleDisputeErr     error
+		claimBlockRewardTxn  common.Hash
+		claimBlockRewardErr  error
+		lastVerification     uint32
+		isFlagPassed         bool
+		handleClaimBountyErr error
 	}
 	tests := []struct {
 		name string
@@ -1203,7 +1200,7 @@ func TestHandleBlock(t *testing.T) {
 			},
 		},
 		{
-			name: "Test 18: When there is no error in dispute and autoClaimBounty flag is passed",
+			name: "Test 18: When there is no error in dispute and HandleClaimBounty flag is passed",
 			args: args{
 				state:          3,
 				epoch:          1,
@@ -1220,21 +1217,21 @@ func TestHandleBlock(t *testing.T) {
 			},
 		},
 		{
-			name: "Test 19: When there is no error in dispute but autoClaimBounty throws error",
+			name: "Test 19: When there is no error in dispute but HandleClaimBounty throws error",
 			args: args{
-				state:              3,
-				epoch:              1,
-				stateName:          "dispute",
-				stakerId:           1,
-				staker:             bindings.StructsStaker{Id: 1, Stake: big.NewInt(10000)},
-				ethBalance:         big.NewInt(1000),
-				minStakeAmount:     big.NewInt(100),
-				actualStake:        big.NewFloat(10000),
-				actualBalance:      big.NewFloat(1000),
-				sRZRBalance:        big.NewInt(10000),
-				sRZRInEth:          big.NewFloat(100),
-				isFlagPassed:       true,
-				autoClaimBountyErr: errors.New("error in autoClaimBounty"),
+				state:                3,
+				epoch:                1,
+				stateName:            "dispute",
+				stakerId:             1,
+				staker:               bindings.StructsStaker{Id: 1, Stake: big.NewInt(10000)},
+				ethBalance:           big.NewInt(1000),
+				minStakeAmount:       big.NewInt(100),
+				actualStake:          big.NewFloat(10000),
+				actualBalance:        big.NewFloat(1000),
+				sRZRBalance:          big.NewInt(10000),
+				sRZRInEth:            big.NewFloat(100),
+				isFlagPassed:         true,
+				handleClaimBountyErr: errors.New("error in handleClaimBounty"),
 			},
 		},
 		{
@@ -1340,7 +1337,7 @@ func TestHandleBlock(t *testing.T) {
 			cmdUtilsMock.On("InitiatePropose", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.initiateProposeErr)
 			cmdUtilsMock.On("HandleDispute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.handleDisputeErr)
 			utilsPkgMock.On("IsFlagPassed", mock.AnythingOfType("string")).Return(tt.args.isFlagPassed)
-			cmdUtilsMock.On("AutoClaimBounty", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.autoClaimBountyErr)
+			cmdUtilsMock.On("HandleClaimBounty", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.handleClaimBountyErr)
 			cmdUtilsMock.On("ClaimBlockReward", mock.Anything).Return(tt.args.claimBlockRewardTxn, tt.args.claimBlockRewardErr)
 			utilsMock.On("WaitForBlockCompletion", mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(1)
 			timeMock.On("Sleep", mock.Anything).Return()
@@ -1348,162 +1345,6 @@ func TestHandleBlock(t *testing.T) {
 			lastVerification = tt.args.lastVerification
 			ut := &UtilsStruct{}
 			ut.HandleBlock(client, account, blockNumber, tt.args.config, rogueData)
-		})
-	}
-}
-
-func TestAutoClaimBounty(t *testing.T) {
-	var (
-		client   *ethclient.Client
-		config   types.Configurations
-		account  types.Account
-		fileInfo fs.FileInfo
-	)
-	type args struct {
-		disputeFilePath    string
-		disputeFilePathErr error
-		disputedFlag       bool
-		latestHeader       *Types.Header
-		latestHeaderErr    error
-		latestBountyId     uint32
-		latestBountyIdErr  error
-		statErr            error
-		disputeData        types.DisputeFileData
-		disputeDataErr     error
-		claimBountyTxn     common.Hash
-		claimBountyTxnErr  error
-		claimBountyStatus  int
-		saveDataErr        error
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "Test 1: When AutoClaimBounty() executes successfully",
-			args: args{
-				disputeFilePath:   "",
-				disputedFlag:      true,
-				latestHeader:      &Types.Header{Number: big.NewInt(1)},
-				latestBountyId:    1,
-				statErr:           nil,
-				disputeData:       types.DisputeFileData{BountyIdQueue: []uint32{1}},
-				claimBountyTxn:    common.BigToHash(big.NewInt(1)),
-				claimBountyStatus: 1,
-				saveDataErr:       nil,
-			},
-			wantErr: false,
-		},
-		{
-			name: "Test 2: When AutoClaimBounty() executes successfully and there are more than one bountyId in queue",
-			args: args{
-				disputeFilePath:   "",
-				disputedFlag:      true,
-				latestHeader:      &Types.Header{Number: big.NewInt(1)},
-				latestBountyId:    1,
-				statErr:           nil,
-				disputeData:       types.DisputeFileData{BountyIdQueue: []uint32{1, 2}},
-				claimBountyTxn:    common.BigToHash(big.NewInt(1)),
-				claimBountyStatus: 1,
-				saveDataErr:       nil,
-			},
-			wantErr: false,
-		},
-		{
-			name: "Test 3: When there is an error in getting disputeFilePath",
-			args: args{
-				disputeFilePathErr: errors.New("error in getting disputeFilePath"),
-			},
-			wantErr: true,
-		},
-		{
-			name: "Test 4: When there is an error in getting latest header",
-			args: args{
-				disputeFilePath: "",
-				disputedFlag:    true,
-				latestHeaderErr: errors.New("error in getting latest header"),
-			},
-			wantErr: true,
-		},
-		{
-			name: "Test 5: When there is an error in not getting latest bountyId",
-			args: args{
-				disputeFilePath:   "",
-				disputedFlag:      true,
-				latestHeader:      &Types.Header{Number: big.NewInt(1)},
-				latestBountyIdErr: errors.New("error in getting latest bountyId"),
-			},
-			wantErr: true,
-		},
-		{
-			name: "Test 6: When there is an error in getting disputeData",
-			args: args{
-				disputeFilePath: "",
-				disputedFlag:    true,
-				latestHeader:    &Types.Header{Number: big.NewInt(1)},
-				latestBountyId:  1,
-				statErr:         nil,
-				disputeDataErr:  errors.New("error in getting diapute data"),
-			},
-			wantErr: true,
-		},
-		{
-			name: "When there is an error in claimBounty",
-			args: args{
-				disputeFilePath:   "",
-				disputedFlag:      true,
-				latestHeader:      &Types.Header{Number: big.NewInt(1)},
-				latestBountyId:    1,
-				statErr:           nil,
-				disputeData:       types.DisputeFileData{BountyIdQueue: []uint32{1}},
-				claimBountyTxnErr: errors.New("error in claimBounty"),
-			},
-			wantErr: true,
-		},
-		{
-			name: "When there is an error in saving data to file",
-			args: args{
-				disputeFilePath:   "",
-				disputedFlag:      true,
-				latestHeader:      &Types.Header{Number: big.NewInt(1)},
-				latestBountyId:    1,
-				statErr:           nil,
-				disputeData:       types.DisputeFileData{BountyIdQueue: []uint32{1}},
-				claimBountyTxn:    common.BigToHash(big.NewInt(1)),
-				claimBountyStatus: 1,
-				saveDataErr:       errors.New("error in saving data to file"),
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			utilsMock := new(mocks.UtilsInterface)
-			cmdUtilsMock := new(mocks.UtilsCmdInterface)
-			utilsPkgMock := new(mocks2.Utils)
-			osUtilsMock := new(pathMocks.OSInterface)
-
-			razorUtils = utilsMock
-			cmdUtils = cmdUtilsMock
-			utils.UtilsInterface = utilsPkgMock
-			utilsInterface = utilsPkgMock
-			path.OSUtilsInterface = osUtilsMock
-
-			utilsMock.On("GetDisputeDataFileName", mock.AnythingOfType("string")).Return(tt.args.disputeFilePath, tt.args.disputeFilePathErr)
-			utilsPkgMock.On("GetLatestBlockWithRetry", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.latestHeader, tt.args.latestHeaderErr)
-			cmdUtilsMock.On("GetBountyIdFromEvents", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.latestBountyId, tt.args.latestBountyIdErr)
-			osUtilsMock.On("Stat", mock.Anything).Return(fileInfo, tt.args.statErr)
-			utilsMock.On("ReadFromDisputeJsonFile", mock.Anything).Return(tt.args.disputeData, tt.args.disputeDataErr)
-			cmdUtilsMock.On("ClaimBounty", mock.Anything, mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(tt.args.claimBountyTxn, tt.args.claimBountyTxnErr)
-			utilsPkgMock.On("WaitForBlockCompletion", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string")).Return(tt.args.claimBountyStatus)
-			utilsMock.On("SaveDataToDisputeJsonFile", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.saveDataErr)
-			disputedFlag = tt.args.disputedFlag
-
-			ut := &UtilsStruct{}
-			if err := ut.AutoClaimBounty(client, config, account); (err != nil) != tt.wantErr {
-				t.Errorf("AutoClaimBounty() error = %v, wantErr %v", err, tt.wantErr)
-			}
 		})
 	}
 }


### PR DESCRIPTION
# Description

- Now bountyIds are stored in a file
-  BountyHunter can also execute `claimBounty` command without passing `bountyId` flag as bountyIds will be picked from disputeData file stored in .razor directory.
- Tests changed with corresponding changes.

Fixes #727
