### PR TITLE
Separate directories to store data and keystore files in .razor

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -6,14 +6,21 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"razor/core/types"
 	"razor/logger"
+	"razor/path"
 	"strings"
 )
 
 var log = logger.NewLogger()
 
 //This function takes path and password as input and returns new account
-func (AccountUtils) CreateAccount(path string, password string) accounts.Account {
-	newAcc, err := AccountUtilsInterface.NewAccount(path, password)
+func (AccountUtils) CreateAccount(keystorePath string, password string) accounts.Account {
+	if _, err := path.OSUtilsInterface.Stat(keystorePath); path.OSUtilsInterface.IsNotExist(err) {
+		mkdirErr := path.OSUtilsInterface.Mkdir(keystorePath, 0700)
+		if mkdirErr != nil {
+			log.Fatal("Error in creating directory: ", mkdirErr)
+		}
+	}
+	newAcc, err := AccountUtilsInterface.NewAccount(keystorePath, password)
 	if err != nil {
 		log.Fatal("Error in creating account: ", err)
 	}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -43,7 +43,7 @@ func (*UtilsStruct) Create(password string) (accounts.Account, error) {
 		log.Error("Error in fetching .razor directory")
 		return accounts.Account{Address: common.Address{0x00}}, err
 	}
-	keystorePath := path.Join(razorPath, "keystoreFiles")
+	keystorePath := path.Join(razorPath, "keystore_files")
 	account := razorAccounts.AccountUtilsInterface.CreateAccount(keystorePath, password)
 	return account, nil
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -42,7 +42,7 @@ func (*UtilsStruct) Create(password string) (accounts.Account, error) {
 		log.Error("Error in fetching .razor directory")
 		return accounts.Account{Address: common.Address{0x00}}, err
 	}
-	account := razorAccounts.AccountUtilsInterface.CreateAccount(path, password)
+	account := razorAccounts.AccountUtilsInterface.CreateAccount(path+"/keystoreFiles", password)
 	return account, nil
 }
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"path"
 	razorAccounts "razor/accounts"
 	"razor/utils"
 )
@@ -37,12 +38,13 @@ func (*UtilsStruct) ExecuteCreate(flagSet *pflag.FlagSet) {
 
 //This function is used to create the new account
 func (*UtilsStruct) Create(password string) (accounts.Account, error) {
-	path, err := razorUtils.GetDefaultPath()
+	razorPath, err := razorUtils.GetDefaultPath()
 	if err != nil {
 		log.Error("Error in fetching .razor directory")
 		return accounts.Account{Address: common.Address{0x00}}, err
 	}
-	account := razorAccounts.AccountUtilsInterface.CreateAccount(path+"/keystoreFiles", password)
+	keystorePath := path.Join(razorPath, "keystoreFiles")
+	account := razorAccounts.AccountUtilsInterface.CreateAccount(keystorePath, password)
 	return account, nil
 }
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -48,7 +48,7 @@ func (*UtilsStruct) ImportAccount() (accounts.Account, error) {
 		return accounts.Account{Address: common.Address{0x00}}, err
 	}
 
-	keystoreDir := pathPkg.Join(razorPath, "keystoreFiles")
+	keystoreDir := pathPkg.Join(razorPath, "keystore_files")
 	if _, err := path.OSUtilsInterface.Stat(keystoreDir); path.OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := path.OSUtilsInterface.Mkdir(keystoreDir, 0700)
 		if mkdirErr != nil {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"razor/path"
 	"razor/utils"
 	"strings"
 )
@@ -40,17 +41,26 @@ func (*UtilsStruct) ImportAccount() (accounts.Account, error) {
 	privateKey = strings.TrimPrefix(privateKey, "0x")
 	log.Info("Enter password to protect keystore file")
 	password := razorUtils.PasswordPrompt()
-	path, err := razorUtils.GetDefaultPath()
+	razorPath, err := razorUtils.GetDefaultPath()
 	if err != nil {
 		log.Error("Error in fetching .razor directory")
 		return accounts.Account{Address: common.Address{0x00}}, err
 	}
+
+	keystoreDir := razorPath + "/keystoreFiles"
+	if _, err := path.OSUtilsInterface.Stat(keystoreDir); path.OSUtilsInterface.IsNotExist(err) {
+		mkdirErr := path.OSUtilsInterface.Mkdir(keystoreDir, 0700)
+		if mkdirErr != nil {
+			return accounts.Account{Address: common.Address{0x00}}, mkdirErr
+		}
+	}
+
 	priv, err := cryptoUtils.HexToECDSA(privateKey)
 	if err != nil {
 		log.Error("Error in parsing private key")
 		return accounts.Account{Address: common.Address{0x00}}, err
 	}
-	account, err := keystoreUtils.ImportECDSA(path, priv, password)
+	account, err := keystoreUtils.ImportECDSA(keystoreDir, priv, password)
 	if err != nil {
 		log.Error("Error in importing account")
 		return accounts.Account{Address: common.Address{0x00}}, err

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	pathPkg "path"
 	"razor/path"
 	"razor/utils"
 	"strings"
@@ -47,7 +48,7 @@ func (*UtilsStruct) ImportAccount() (accounts.Account, error) {
 		return accounts.Account{Address: common.Address{0x00}}, err
 	}
 
-	keystoreDir := razorPath + "/keystoreFiles"
+	keystoreDir := pathPkg.Join(razorPath, "keystoreFiles")
 	if _, err := path.OSUtilsInterface.Stat(keystoreDir); path.OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := path.OSUtilsInterface.Mkdir(keystoreDir, 0700)
 		if mkdirErr != nil {

--- a/cmd/listAccounts.go
+++ b/cmd/listAccounts.go
@@ -42,7 +42,7 @@ func (*UtilsStruct) ListAccounts() ([]accounts.Account, error) {
 		return nil, err
 	}
 
-	keystorePath := pathPkg.Join(path, "keystoreFiles")
+	keystorePath := pathPkg.Join(path, "keystore_files")
 	return keystoreUtils.Accounts(keystorePath), nil
 }
 

--- a/cmd/listAccounts.go
+++ b/cmd/listAccounts.go
@@ -5,6 +5,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	pathPkg "path"
 	"razor/utils"
 )
 
@@ -41,7 +42,8 @@ func (*UtilsStruct) ListAccounts() ([]accounts.Account, error) {
 		return nil, err
 	}
 
-	return keystoreUtils.Accounts(path + "/keystoreFiles"), nil
+	keystorePath := pathPkg.Join(path, "keystoreFiles")
+	return keystoreUtils.Accounts(keystorePath), nil
 }
 
 func init() {

--- a/cmd/listAccounts.go
+++ b/cmd/listAccounts.go
@@ -41,7 +41,7 @@ func (*UtilsStruct) ListAccounts() ([]accounts.Account, error) {
 		return nil, err
 	}
 
-	return keystoreUtils.Accounts(path), nil
+	return keystoreUtils.Accounts(path + "/keystoreFiles"), nil
 }
 
 func init() {

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -498,7 +498,7 @@ func (*UtilsStruct) CalculateSecret(account types.Account, epoch uint32) ([]byte
 	if err != nil {
 		return nil, errors.New("Error in fetching .razor directory: " + err.Error())
 	}
-	keystorePath := path.Join(razorPath, "keystoreFiles")
+	keystorePath := path.Join(razorPath, "keystore_files")
 	signedData, err := accounts.AccountUtilsInterface.SignData(hash, account, keystorePath)
 	if err != nil {
 		return nil, errors.New("Error in signing the data: " + err.Error())

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -497,7 +497,7 @@ func (*UtilsStruct) CalculateSecret(account types.Account, epoch uint32) ([]byte
 	if err != nil {
 		return nil, errors.New("Error in fetching .razor directory: " + err.Error())
 	}
-	signedData, err := accounts.AccountUtilsInterface.SignData(hash, account, razorPath)
+	signedData, err := accounts.AccountUtilsInterface.SignData(hash, account, razorPath+"/keystoreFiles")
 	if err != nil {
 		return nil, errors.New("Error in signing the data: " + err.Error())
 	}

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"os"
 	"os/signal"
+	"path"
 	"razor/accounts"
 	"razor/core"
 	"razor/core/types"
@@ -497,7 +498,8 @@ func (*UtilsStruct) CalculateSecret(account types.Account, epoch uint32) ([]byte
 	if err != nil {
 		return nil, errors.New("Error in fetching .razor directory: " + err.Error())
 	}
-	signedData, err := accounts.AccountUtilsInterface.SignData(hash, account, razorPath+"/keystoreFiles")
+	keystorePath := path.Join(razorPath, "keystoreFiles")
+	signedData, err := accounts.AccountUtilsInterface.SignData(hash, account, keystorePath)
 	if err != nil {
 		return nil, errors.New("Error in signing the data: " + err.Error())
 	}

--- a/path/path.go
+++ b/path/path.go
@@ -62,7 +62,7 @@ func (PathUtils) GetCommitDataFileName(address string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dataFileDir := pathPkg.Join(razorDir, "dataFiles")
+	dataFileDir := pathPkg.Join(razorDir, "data_files")
 	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
 		if mkdirErr != nil {
@@ -79,7 +79,7 @@ func (PathUtils) GetProposeDataFileName(address string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dataFileDir := pathPkg.Join(razorDir, "dataFiles")
+	dataFileDir := pathPkg.Join(razorDir, "data_files")
 	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
 		if mkdirErr != nil {
@@ -95,7 +95,7 @@ func (PathUtils) GetDisputeDataFileName(address string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dataFileDir := pathPkg.Join(razorDir, "dataFiles")
+	dataFileDir := pathPkg.Join(razorDir, "data_files")
 	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
 		if mkdirErr != nil {

--- a/path/path.go
+++ b/path/path.go
@@ -59,7 +59,15 @@ func (PathUtils) GetCommitDataFileName(address string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return homeDir + "/" + address + "_CommitData.json", nil
+	dataFileDir := homeDir + "/dataFiles"
+	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
+		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
+		if mkdirErr != nil {
+			return "", mkdirErr
+		}
+	}
+
+	return dataFileDir + "/" + address + "_CommitData.json", nil
 }
 
 //This function returns the file name of propose data file
@@ -68,7 +76,14 @@ func (PathUtils) GetProposeDataFileName(address string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return homeDir + "/" + address + "_proposedData.json", nil
+	dataFileDir := homeDir + "/dataFiles"
+	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
+		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
+		if mkdirErr != nil {
+			return "", mkdirErr
+		}
+	}
+	return dataFileDir + "/" + address + "_proposedData.json", nil
 }
 
 //This function returns the file name of dispute data file
@@ -77,5 +92,12 @@ func (PathUtils) GetDisputeDataFileName(address string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return homeDir + "/" + address + "_disputeData.json", nil
+	dataFileDir := homeDir + "/dataFiles"
+	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
+		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
+		if mkdirErr != nil {
+			return "", mkdirErr
+		}
+	}
+	return dataFileDir + "/" + address + "_disputeData.json", nil
 }

--- a/path/path.go
+++ b/path/path.go
@@ -1,7 +1,10 @@
 //Package path provides all path related functions
 package path
 
-import "os"
+import (
+	"os"
+	pathPkg "path"
+)
 
 //This function returns the default path
 func (PathUtils) GetDefaultPath() (string, error) {
@@ -9,7 +12,7 @@ func (PathUtils) GetDefaultPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defaultPath := home + "/.razor"
+	defaultPath := pathPkg.Join(home, ".razor")
 	if _, err := OSUtilsInterface.Stat(defaultPath); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(defaultPath, 0700)
 		if mkdirErr != nil {
@@ -21,11 +24,11 @@ func (PathUtils) GetDefaultPath() (string, error) {
 
 //This function returns the log file path
 func (PathUtils) GetLogFilePath(fileName string) (string, error) {
-	home, err := PathUtilsInterface.GetDefaultPath()
+	razorPath, err := PathUtilsInterface.GetDefaultPath()
 	if err != nil {
 		return "", err
 	}
-	filePath := home + "/" + fileName + ".log"
+	filePath := pathPkg.Join(razorPath, fileName+".log")
 	f, err := OSUtilsInterface.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return "", err
@@ -36,30 +39,30 @@ func (PathUtils) GetLogFilePath(fileName string) (string, error) {
 
 //This function returns the config file path
 func (PathUtils) GetConfigFilePath() (string, error) {
-	home, err := PathUtilsInterface.GetDefaultPath()
+	razorPath, err := PathUtilsInterface.GetDefaultPath()
 	if err != nil {
 		return "", err
 	}
-	return home + "/razor.yaml", nil
+	return pathPkg.Join(razorPath, "razor.yaml"), nil
 }
 
 //This function returns the job file path
 func (PathUtils) GetJobFilePath() (string, error) {
-	home, err := PathUtilsInterface.GetDefaultPath()
+	razorPath, err := PathUtilsInterface.GetDefaultPath()
 	if err != nil {
 		return "", err
 	}
-	filePath := home + "/assets.json"
+	filePath := pathPkg.Join(razorPath, "assets.json")
 	return filePath, nil
 }
 
 //This function returns the file name of commit data file
 func (PathUtils) GetCommitDataFileName(address string) (string, error) {
-	homeDir, err := PathUtilsInterface.GetDefaultPath()
+	razorDir, err := PathUtilsInterface.GetDefaultPath()
 	if err != nil {
 		return "", err
 	}
-	dataFileDir := homeDir + "/dataFiles"
+	dataFileDir := pathPkg.Join(razorDir, "dataFiles")
 	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
 		if mkdirErr != nil {
@@ -67,37 +70,37 @@ func (PathUtils) GetCommitDataFileName(address string) (string, error) {
 		}
 	}
 
-	return dataFileDir + "/" + address + "_CommitData.json", nil
+	return pathPkg.Join(dataFileDir, address+"_CommitData.json"), nil
 }
 
 //This function returns the file name of propose data file
 func (PathUtils) GetProposeDataFileName(address string) (string, error) {
-	homeDir, err := PathUtilsInterface.GetDefaultPath()
+	razorDir, err := PathUtilsInterface.GetDefaultPath()
 	if err != nil {
 		return "", err
 	}
-	dataFileDir := homeDir + "/dataFiles"
+	dataFileDir := pathPkg.Join(razorDir, "dataFiles")
 	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
 		if mkdirErr != nil {
 			return "", mkdirErr
 		}
 	}
-	return dataFileDir + "/" + address + "_proposedData.json", nil
+	return pathPkg.Join(dataFileDir, address+"_proposedData.json"), nil
 }
 
 //This function returns the file name of dispute data file
 func (PathUtils) GetDisputeDataFileName(address string) (string, error) {
-	homeDir, err := PathUtilsInterface.GetDefaultPath()
+	razorDir, err := PathUtilsInterface.GetDefaultPath()
 	if err != nil {
 		return "", err
 	}
-	dataFileDir := homeDir + "/dataFiles"
+	dataFileDir := pathPkg.Join(razorDir, "dataFiles")
 	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
 		if mkdirErr != nil {
 			return "", mkdirErr
 		}
 	}
-	return dataFileDir + "/" + address + "_disputeData.json", nil
+	return pathPkg.Join(dataFileDir, address+"_disputeData.json"), nil
 }

--- a/path/path_test.go
+++ b/path/path_test.go
@@ -291,7 +291,7 @@ func TestGetCommitDataFileName(t *testing.T) {
 				address: "0x000000000000000000000000000000000000dead",
 				path:    "/home",
 			},
-			want:    "/home/dataFiles/0x000000000000000000000000000000000000dead_CommitData.json",
+			want:    "/home/data_files/0x000000000000000000000000000000000000dead_CommitData.json",
 			wantErr: nil,
 		},
 		{
@@ -304,18 +304,18 @@ func TestGetCommitDataFileName(t *testing.T) {
 			wantErr: errors.New("path error"),
 		},
 		{
-			name: "Test 3: When dataFiles directory is not present and mkdir creates it",
+			name: "Test 3: When data_files directory is not present and mkdir creates it",
 			args: args{
 				address:    "0x000000000000000000000000000000000000dead",
 				path:       "/home",
 				statErr:    errors.New("not exists"),
 				isNotExist: true,
 			},
-			want:    "/home/dataFiles/0x000000000000000000000000000000000000dead_CommitData.json",
+			want:    "/home/data_files/0x000000000000000000000000000000000000dead_CommitData.json",
 			wantErr: nil,
 		},
 		{
-			name: "Test 4: When dataFiles directory is not present and there is an error in creating new one",
+			name: "Test 4: When data_files directory is not present and there is an error in creating new one",
 			args: args{
 				address:    "0x000000000000000000000000000000000000dead",
 				path:       "/home",
@@ -382,7 +382,7 @@ func TestGetProposeDataFileName(t *testing.T) {
 				address: "0x000000000000000000000000000000000000dead",
 				path:    "/home",
 			},
-			want:    "/home/dataFiles/0x000000000000000000000000000000000000dead_proposedData.json",
+			want:    "/home/data_files/0x000000000000000000000000000000000000dead_proposedData.json",
 			wantErr: nil,
 		},
 		{
@@ -395,18 +395,18 @@ func TestGetProposeDataFileName(t *testing.T) {
 			wantErr: errors.New("path error"),
 		},
 		{
-			name: "Test 3: When dataFiles directory is not present and mkdir creates it",
+			name: "Test 3: When data_files directory is not present and mkdir creates it",
 			args: args{
 				address:    "0x000000000000000000000000000000000000dead",
 				path:       "/home",
 				statErr:    errors.New("not exists"),
 				isNotExist: true,
 			},
-			want:    "/home/dataFiles/0x000000000000000000000000000000000000dead_proposedData.json",
+			want:    "/home/data_files/0x000000000000000000000000000000000000dead_proposedData.json",
 			wantErr: nil,
 		},
 		{
-			name: "Test 4: When dataFiles directory is not present and there is an error in creating new one",
+			name: "Test 4: When data_files directory is not present and there is an error in creating new one",
 			args: args{
 				address:    "0x000000000000000000000000000000000000dead",
 				path:       "/home",
@@ -473,7 +473,7 @@ func TestGetDisputeDataFileName(t *testing.T) {
 				address: "0x000000000000000000000000000000000000dead",
 				path:    "/home",
 			},
-			want:    "/home/dataFiles/0x000000000000000000000000000000000000dead_disputeData.json",
+			want:    "/home/data_files/0x000000000000000000000000000000000000dead_disputeData.json",
 			wantErr: nil,
 		},
 		{
@@ -486,18 +486,18 @@ func TestGetDisputeDataFileName(t *testing.T) {
 			wantErr: errors.New("path error"),
 		},
 		{
-			name: "Test 3: When dataFiles directory is not present and mkdir creates it",
+			name: "Test 3: When data_files directory is not present and mkdir creates it",
 			args: args{
 				address:    "0x000000000000000000000000000000000000dead",
 				path:       "/home",
 				statErr:    errors.New("not exists"),
 				isNotExist: true,
 			},
-			want:    "/home/dataFiles/0x000000000000000000000000000000000000dead_disputeData.json",
+			want:    "/home/data_files/0x000000000000000000000000000000000000dead_disputeData.json",
 			wantErr: nil,
 		},
 		{
-			name: "Test 4: When dataFiles directory is not present and there is an error in creating new one",
+			name: "Test 4: When data_files directory is not present and there is an error in creating new one",
 			args: args{
 				address:    "0x000000000000000000000000000000000000dead",
 				path:       "/home",

--- a/path/path_test.go
+++ b/path/path_test.go
@@ -111,9 +111,9 @@ func TestGetLogFilePath(t *testing.T) {
 		{
 			name: "Test 1: When GetLogFilePath() executes successfully",
 			args: args{
-				path: "./home/.razor",
+				path: "/home/.razor",
 			},
-			want:    "./home/.razor/.log",
+			want:    "/home/.razor/.log",
 			wantErr: nil,
 		},
 		{
@@ -127,7 +127,7 @@ func TestGetLogFilePath(t *testing.T) {
 		{
 			name: "Test 3: When there is an error in getting file",
 			args: args{
-				path:    "./home/.razor",
+				path:    "/home/.razor",
 				fileErr: errors.New("error in getting file"),
 			},
 			want:    "",
@@ -176,9 +176,9 @@ func TestGetConfigFilePath(t *testing.T) {
 		{
 			name: "Test 1: When GetConfigFilePath() executes successfully",
 			args: args{
-				path: "./home/.razor",
+				path: "/home/.razor",
 			},
-			want:    "./home/.razor/razor.yaml",
+			want:    "/home/.razor/razor.yaml",
 			wantErr: nil,
 		},
 		{

--- a/path/path_test.go
+++ b/path/path_test.go
@@ -269,10 +269,15 @@ func TestGetJobFilePath(t *testing.T) {
 }
 
 func TestGetCommitDataFileName(t *testing.T) {
+	var fileInfo fs.FileInfo
+
 	type args struct {
-		address string
-		path    string
-		pathErr error
+		address    string
+		path       string
+		pathErr    error
+		statErr    error
+		isNotExist bool
+		mkdirErr   error
 	}
 	tests := []struct {
 		name    string
@@ -286,7 +291,7 @@ func TestGetCommitDataFileName(t *testing.T) {
 				address: "0x000000000000000000000000000000000000dead",
 				path:    "/home",
 			},
-			want:    "/home/0x000000000000000000000000000000000000dead_CommitData.json",
+			want:    "/home/dataFiles/0x000000000000000000000000000000000000dead_CommitData.json",
 			wantErr: nil,
 		},
 		{
@@ -298,14 +303,43 @@ func TestGetCommitDataFileName(t *testing.T) {
 			want:    "",
 			wantErr: errors.New("path error"),
 		},
+		{
+			name: "Test 3: When dataFiles directory is not present and mkdir creates it",
+			args: args{
+				address:    "0x000000000000000000000000000000000000dead",
+				path:       "/home",
+				statErr:    errors.New("not exists"),
+				isNotExist: true,
+			},
+			want:    "/home/dataFiles/0x000000000000000000000000000000000000dead_CommitData.json",
+			wantErr: nil,
+		},
+		{
+			name: "Test 4: When dataFiles directory is not present and there is an error in creating new one",
+			args: args{
+				address:    "0x000000000000000000000000000000000000dead",
+				path:       "/home",
+				statErr:    errors.New("not exists"),
+				isNotExist: true,
+				mkdirErr:   errors.New("mkdir error"),
+			},
+			want:    "",
+			wantErr: errors.New("mkdir error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
 			pathMock := new(mocks.PathInterface)
+			osMock := new(mocks.OSInterface)
+
+			OSUtilsInterface = osMock
 			PathUtilsInterface = pathMock
 
 			pathMock.On("GetDefaultPath").Return(tt.args.path, tt.args.pathErr)
+			osMock.On("Stat", mock.AnythingOfType("string")).Return(fileInfo, tt.args.statErr)
+			osMock.On("IsNotExist", mock.Anything).Return(tt.args.isNotExist)
+			osMock.On("Mkdir", mock.Anything, mock.Anything).Return(tt.args.mkdirErr)
 
 			pa := &PathUtils{}
 			got, err := pa.GetCommitDataFileName(tt.args.address)
@@ -326,10 +360,15 @@ func TestGetCommitDataFileName(t *testing.T) {
 }
 
 func TestGetProposeDataFileName(t *testing.T) {
+	var fileInfo fs.FileInfo
+
 	type args struct {
-		address string
-		path    string
-		pathErr error
+		address    string
+		path       string
+		pathErr    error
+		statErr    error
+		isNotExist bool
+		mkdirErr   error
 	}
 	tests := []struct {
 		name    string
@@ -343,7 +382,7 @@ func TestGetProposeDataFileName(t *testing.T) {
 				address: "0x000000000000000000000000000000000000dead",
 				path:    "/home",
 			},
-			want:    "/home/0x000000000000000000000000000000000000dead_proposedData.json",
+			want:    "/home/dataFiles/0x000000000000000000000000000000000000dead_proposedData.json",
 			wantErr: nil,
 		},
 		{
@@ -355,14 +394,43 @@ func TestGetProposeDataFileName(t *testing.T) {
 			want:    "",
 			wantErr: errors.New("path error"),
 		},
+		{
+			name: "Test 3: When dataFiles directory is not present and mkdir creates it",
+			args: args{
+				address:    "0x000000000000000000000000000000000000dead",
+				path:       "/home",
+				statErr:    errors.New("not exists"),
+				isNotExist: true,
+			},
+			want:    "/home/dataFiles/0x000000000000000000000000000000000000dead_proposedData.json",
+			wantErr: nil,
+		},
+		{
+			name: "Test 4: When dataFiles directory is not present and there is an error in creating new one",
+			args: args{
+				address:    "0x000000000000000000000000000000000000dead",
+				path:       "/home",
+				statErr:    errors.New("not exists"),
+				isNotExist: true,
+				mkdirErr:   errors.New("mkdir error"),
+			},
+			want:    "",
+			wantErr: errors.New("mkdir error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
 			pathMock := new(mocks.PathInterface)
+			osMock := new(mocks.OSInterface)
+
+			OSUtilsInterface = osMock
 			PathUtilsInterface = pathMock
 
 			pathMock.On("GetDefaultPath").Return(tt.args.path, tt.args.pathErr)
+			osMock.On("Stat", mock.AnythingOfType("string")).Return(fileInfo, tt.args.statErr)
+			osMock.On("IsNotExist", mock.Anything).Return(tt.args.isNotExist)
+			osMock.On("Mkdir", mock.Anything, mock.Anything).Return(tt.args.mkdirErr)
 
 			pa := &PathUtils{}
 			got, err := pa.GetProposeDataFileName(tt.args.address)
@@ -383,10 +451,15 @@ func TestGetProposeDataFileName(t *testing.T) {
 }
 
 func TestGetDisputeDataFileName(t *testing.T) {
+	var fileInfo fs.FileInfo
+
 	type args struct {
-		address string
-		path    string
-		pathErr error
+		address    string
+		path       string
+		pathErr    error
+		statErr    error
+		isNotExist bool
+		mkdirErr   error
 	}
 	tests := []struct {
 		name    string
@@ -400,7 +473,7 @@ func TestGetDisputeDataFileName(t *testing.T) {
 				address: "0x000000000000000000000000000000000000dead",
 				path:    "/home",
 			},
-			want:    "/home/0x000000000000000000000000000000000000dead_disputeData.json",
+			want:    "/home/dataFiles/0x000000000000000000000000000000000000dead_disputeData.json",
 			wantErr: nil,
 		},
 		{
@@ -412,14 +485,43 @@ func TestGetDisputeDataFileName(t *testing.T) {
 			want:    "",
 			wantErr: errors.New("path error"),
 		},
+		{
+			name: "Test 3: When dataFiles directory is not present and mkdir creates it",
+			args: args{
+				address:    "0x000000000000000000000000000000000000dead",
+				path:       "/home",
+				statErr:    errors.New("not exists"),
+				isNotExist: true,
+			},
+			want:    "/home/dataFiles/0x000000000000000000000000000000000000dead_disputeData.json",
+			wantErr: nil,
+		},
+		{
+			name: "Test 4: When dataFiles directory is not present and there is an error in creating new one",
+			args: args{
+				address:    "0x000000000000000000000000000000000000dead",
+				path:       "/home",
+				statErr:    errors.New("not exists"),
+				isNotExist: true,
+				mkdirErr:   errors.New("mkdir error"),
+			},
+			want:    "",
+			wantErr: errors.New("mkdir error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
 			pathMock := new(mocks.PathInterface)
+			osMock := new(mocks.OSInterface)
+
+			OSUtilsInterface = osMock
 			PathUtilsInterface = pathMock
 
 			pathMock.On("GetDefaultPath").Return(tt.args.path, tt.args.pathErr)
+			osMock.On("Stat", mock.AnythingOfType("string")).Return(fileInfo, tt.args.statErr)
+			osMock.On("IsNotExist", mock.Anything).Return(tt.args.isNotExist)
+			osMock.On("Mkdir", mock.Anything, mock.Anything).Return(tt.args.mkdirErr)
 
 			pa := &PathUtils{}
 			got, err := pa.GetDisputeDataFileName(tt.args.address)

--- a/utils/options.go
+++ b/utils/options.go
@@ -31,7 +31,7 @@ func (*UtilsStruct) GetOptions() bind.CallOpts {
 func (*UtilsStruct) GetTxnOpts(transactionData types.TransactionOptions) *bind.TransactOpts {
 	defaultPath, err := PathInterface.GetDefaultPath()
 	CheckError("Error in fetching default path: ", err)
-	privateKey := AccountsInterface.GetPrivateKey(transactionData.AccountAddress, transactionData.Password, defaultPath)
+	privateKey := AccountsInterface.GetPrivateKey(transactionData.AccountAddress, transactionData.Password, defaultPath+"/keystoreFiles")
 	if privateKey == nil {
 		CheckError("Error in fetching private key: ", errors.New(transactionData.AccountAddress+" not present in razor-go"))
 	}

--- a/utils/options.go
+++ b/utils/options.go
@@ -4,6 +4,7 @@ package utils
 import (
 	"context"
 	"errors"
+	"path"
 	"razor/core/types"
 	"strings"
 
@@ -31,7 +32,8 @@ func (*UtilsStruct) GetOptions() bind.CallOpts {
 func (*UtilsStruct) GetTxnOpts(transactionData types.TransactionOptions) *bind.TransactOpts {
 	defaultPath, err := PathInterface.GetDefaultPath()
 	CheckError("Error in fetching default path: ", err)
-	privateKey := AccountsInterface.GetPrivateKey(transactionData.AccountAddress, transactionData.Password, defaultPath+"/keystoreFiles")
+	keystorePath := path.Join(defaultPath, "keystoreFiles")
+	privateKey := AccountsInterface.GetPrivateKey(transactionData.AccountAddress, transactionData.Password, keystorePath)
 	if privateKey == nil {
 		CheckError("Error in fetching private key: ", errors.New(transactionData.AccountAddress+" not present in razor-go"))
 	}

--- a/utils/options.go
+++ b/utils/options.go
@@ -32,7 +32,7 @@ func (*UtilsStruct) GetOptions() bind.CallOpts {
 func (*UtilsStruct) GetTxnOpts(transactionData types.TransactionOptions) *bind.TransactOpts {
 	defaultPath, err := PathInterface.GetDefaultPath()
 	CheckError("Error in fetching default path: ", err)
-	keystorePath := path.Join(defaultPath, "keystoreFiles")
+	keystorePath := path.Join(defaultPath, "keystore_files")
 	privateKey := AccountsInterface.GetPrivateKey(transactionData.AccountAddress, transactionData.Password, keystorePath)
 	if privateKey == nil {
 		CheckError("Error in fetching private key: ", errors.New(transactionData.AccountAddress+" not present in razor-go"))


### PR DESCRIPTION
# Description

Now data files(commit, propose and dispute data) and keystore files are stored in a separate directories in `.razor`. 

Fixes #740
