### PR TITLE
Password policy improved.

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -29,6 +29,7 @@ func initialiseCreate(cmd *cobra.Command, args []string) {
 //This function sets the flags appropriately and executes the Create function
 func (*UtilsStruct) ExecuteCreate(flagSet *pflag.FlagSet) {
 	razorUtils.AssignLogFile(flagSet)
+	log.Info("The password should be of minimum 8 characters containing least 1 uppercase, lowercase, digit and special character.")
 	password := razorUtils.AssignPassword(flagSet)
 	account, err := cmdUtils.Create(password)
 	utils.CheckError("Create error: ", err)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -41,6 +41,7 @@ func (*UtilsStruct) ImportAccount() (accounts.Account, error) {
 	// Remove 0x from the private key
 	privateKey = strings.TrimPrefix(privateKey, "0x")
 	log.Info("Enter password to protect keystore file")
+	log.Info("The password should be of minimum 8 characters containing least 1 uppercase, lowercase, digit and special character.")
 	password := razorUtils.PasswordPrompt()
 	razorPath, err := razorUtils.GetDefaultPath()
 	if err != nil {

--- a/utils/password.go
+++ b/utils/password.go
@@ -7,6 +7,7 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/pflag"
 	"os"
+	"unicode"
 )
 
 //This function prompts the password
@@ -39,7 +40,7 @@ func PrivateKeyPrompt() string {
 
 //This function validates the password
 func validate(input string) error {
-	if input == "" {
+	if input == "" || !strongPassword(input) {
 		return errors.New("enter a valid password")
 	}
 	return nil
@@ -80,4 +81,24 @@ func AssignPassword(flagset *pflag.FlagSet) string {
 		return GetPasswordFromFile(passwordPath)
 	}
 	return PasswordPrompt()
+}
+
+//This function checks if the password is strong enough or not
+func strongPassword(input string) bool {
+	l, u, p, d := 0, 0, 0, 0
+	if len(input) >= 8 {
+		for _, char := range input {
+			switch {
+			case unicode.IsUpper(char):
+				u += 1
+			case unicode.IsLower(char):
+				l += 1
+			case unicode.IsNumber(char):
+				d += 1
+			case unicode.IsPunct(char) || unicode.IsSymbol(char):
+				p += 1
+			}
+		}
+	}
+	return (l >= 1 && u >= 1 && p >= 1 && d >= 1) && (l+u+p+d == len(input))
 }

--- a/utils/password_test.go
+++ b/utils/password_test.go
@@ -1,0 +1,23 @@
+package utils
+
+import "testing"
+
+func Test_strongPassword(t *testing.T) {
+	type args struct {
+		input string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := strongPassword(tt.args.input); got != tt.want {
+				t.Errorf("strongPassword() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/utils/password_test.go
+++ b/utils/password_test.go
@@ -11,7 +11,55 @@ func Test_strongPassword(t *testing.T) {
 		args args
 		want bool
 	}{
-		// TODO: Add test cases.
+		{
+			name: "When strongPassword() returns true and every condition is met",
+			args: args{
+				input: "Qwerty12@",
+			},
+			want: true,
+		},
+		{
+			name: "When strongPassword() returns false",
+			args: args{
+				input: "test",
+			},
+			want: false,
+		},
+		{
+			name: "When password does not contain uppercase letters",
+			args: args{
+				input: "qwerty12@",
+			},
+			want: false,
+		},
+		{
+			name: "When password does not contain lowercase letters",
+			args: args{
+				input: "QWERTY12@",
+			},
+			want: false,
+		},
+		{
+			name: "When password does not contain digits",
+			args: args{
+				input: "qwerty!#%@",
+			},
+			want: false,
+		},
+		{
+			name: "When password does not contain special character",
+			args: args{
+				input: "qwerty1234",
+			},
+			want: false,
+		},
+		{
+			name: "When password is not long enough",
+			args: args{
+				input: "Qw1@",
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

- strongPassword function added which checks if the password is within the requirements or not.
- Tests added for strongPassword function in utils/password_test.go.
- Info added for password policy in cmd/create.go and cmd/create.go.

NOTE : We can't use regular expression in go lang for such validation as it does not support backtracking.
https://stackoverflow.com/questions/25837241/password-validation-with-regexp

NOTE : In order to work perfectly, all the accounts which are already imported in razor-go needs to be removed and imported again.

Fixes #752 