### PR TITLE
crypto/rand is used instead of math/rand

### DIFF
--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"github.com/ethereum/go-ethereum/common"
@@ -9,7 +10,6 @@ import (
 	solsha3 "github.com/miguelmota/go-solidity-sha3"
 	"math"
 	"math/big"
-	"math/rand"
 	"razor/core"
 	"razor/core/types"
 	"razor/pkg/bindings"
@@ -55,7 +55,8 @@ func (*UtilsStruct) Propose(client *ethclient.Client, config types.Configuration
 
 	if rogueData.IsRogue && utils.Contains(rogueData.RogueMode, "biggestStakerId") {
 		biggestStake = utils.GetRogueRandomValue(1000000)
-		biggestStakerId = uint32(rand.Intn(int(numStakers)))
+		biggestStakerIdInBigInt, _ := rand.Int(rand.Reader, big.NewInt(int64(numStakers)))
+		biggestStakerId = uint32(biggestStakerIdInBigInt.Int64())
 	} else {
 		biggestStake, biggestStakerId, biggestStakerErr = cmdUtils.GetBiggestStakeAndId(client, account.Address, epoch)
 		if biggestStakerErr != nil {

--- a/utils/math.go
+++ b/utils/math.go
@@ -2,10 +2,10 @@
 package utils
 
 import (
+	"crypto/rand"
 	"errors"
 	"math"
 	"math/big"
-	"math/rand"
 	"sort"
 	"strconv"
 )
@@ -182,10 +182,13 @@ func GetRogueRandomValue(value int) *big.Int {
 	if value <= 0 {
 		return big.NewInt(0)
 	}
-	return big.NewInt(int64(rand.Intn(value)))
+	rogueRandomValue, _ := rand.Int(rand.Reader, big.NewInt(int64(value)))
+	return rogueRandomValue
+
 }
 
 //This function returns the rogue random median value
 func GetRogueRandomMedianValue() uint32 {
-	return rand.Uint32()
+	rogueRandomMedianValue, _ := rand.Int(rand.Reader, big.NewInt(math.MaxInt32))
+	return uint32(rogueRandomMedianValue.Int64())
 }


### PR DESCRIPTION
# Description

- crypto/rand is used instead of math/rand in cmd/propose.go and utils/math.go
- math/rand is used in cmd/dispute.go as it uses rand.Perm function which is provided by only math/rand package.

Fixes #753 