### PR TITLE
Compiler flags added in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ fetch_bindings:
 
 install_razor:
 	@echo "Installing razor node...."
-	${GO} build -o ./build/bin/razor main.go
+	${GO} build -ldflags "-s -w" -o ./build/bin/razor main.go
 	@echo "Razor node installed."
 	@echo ""
 


### PR DESCRIPTION
# Description

- Configured the relevant go-compiler build flags.
-  -ldflags "-s -w" flag added
    - The -w turns off DWARF debugging information.
    - The -s turns off generation of the Go symbol table.

Fixes #756 