### PR TITLE
V1 audit hotfix [Reveal event indexing]

### DIFF
--- a/cmd/reveal.go
+++ b/cmd/reveal.go
@@ -127,7 +127,7 @@ func (*UtilsStruct) IndexRevealEventsOfCurrentEpoch(client *ethclient.Client, bl
 			continue
 		}
 		if epoch == data[0].(uint32) {
-			treeValues := data[3].([]struct {
+			treeValues := data[2].([]struct {
 				LeafId uint16   `json:"leafId"`
 				Value  *big.Int `json:"value"`
 			})
@@ -140,7 +140,7 @@ func (*UtilsStruct) IndexRevealEventsOfCurrentEpoch(client *ethclient.Client, bl
 			}
 			consolidatedRevealedData := types.RevealedStruct{
 				RevealedValues: revealedValues,
-				Influence:      data[2].(*big.Int),
+				Influence:      data[1].(*big.Int),
 			}
 			revealedData = append(revealedData, consolidatedRevealedData)
 		}


### PR DESCRIPTION
# Description

If the event parameters are indexed, then go-ethereum doesn't show them in data, rather it shows them in topics. Due to this reveal events were going wrong. This PR Fixes that.

"If your solidity event contains indexed event types, then they become a topic rather than part of the data property of the log. In solidity you may only have up to 4 topics but only 3 indexed event types. The first topic is always the [signature](https://goethereumbook.org/GLOSSARY.html#signature) of the event."

Fixes #790 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [ ] Tested on staging.razorscan.io

**Test Configuration**:
* Contracts version: `v1-audit-feedback`
* Hardware: Mac M1

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules