### PR TITLE
feat: Configure SSL for metric server

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,8 +662,13 @@ Example:
 
 razor cli
 
+Without TLS
 ```
 $ ./razor setConfig --exposeMetrics 2112
+```
+With TLS
+```
+$ ./razor setConfig --exposeMetrics 2112 --certFile /cert/file/path/certfile.crt --certKey key/file/path/keyfile.key
 ```
 
 docker
@@ -673,8 +678,11 @@ docker
 
 docker network create razor_network
 
-# Expose Metrics
+# Expose Metrics without TLS
 docker exec -it razor-go razor setConfig --exposeMetrics 2112
+
+# Expose Metrics with TLS
+docker exec -it razor-go razor setConfig --exposeMetrics 2112 --certFile /cert/file/path/certfile.crt --certKey key/file/path/keyfile.key
 ```
 
 ### Override Job and Adding Your Custom Jobs

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -4,6 +4,13 @@ package cmd
 import (
 	"context"
 	"crypto/ecdsa"
+	"math/big"
+	Accounts "razor/accounts"
+	"razor/core/types"
+	"razor/path"
+	"razor/pkg/bindings"
+	"time"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -11,12 +18,6 @@ import (
 	Types "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/spf13/pflag"
-	"math/big"
-	Accounts "razor/accounts"
-	"razor/core/types"
-	"razor/path"
-	"razor/pkg/bindings"
-	"time"
 )
 
 //go:generate mockery --name UtilsInterface --output ./mocks/ --case=underscore
@@ -224,6 +225,8 @@ type FlagSetInterface interface {
 	GetBoolRogue(flagSet *pflag.FlagSet) (bool, error)
 	GetStringSliceRogueMode(flagSet *pflag.FlagSet) ([]string, error)
 	GetStringExposeMetrics(flagSet *pflag.FlagSet) (string, error)
+	GetStringCertFile(flagSet *pflag.FlagSet) (string, error)
+	GetStringCertKey(flagSet *pflag.FlagSet) (string, error)	
 }
 
 type UtilsCmdInterface interface {

--- a/cmd/mocks/flag_set_interface.go
+++ b/cmd/mocks/flag_set_interface.go
@@ -369,6 +369,48 @@ func (_m *FlagSetInterface) GetStringExposeMetrics(flagSet *pflag.FlagSet) (stri
 	return r0, r1
 }
 
+// GetStringCertKey provides a mock function with given fields: flagSet
+func (_m *FlagSetInterface) GetStringCertKey(flagSet *pflag.FlagSet) (string, error) {
+	ret := _m.Called(flagSet)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(*pflag.FlagSet) string); ok {
+		r0 = rf(flagSet)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*pflag.FlagSet) error); ok {
+		r1 = rf(flagSet)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetStringCertFile provides a mock function with given fields: flagSet
+func (_m *FlagSetInterface) GetStringCertFile(flagSet *pflag.FlagSet) (string, error) {
+	ret := _m.Called(flagSet)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(*pflag.FlagSet) string); ok {
+		r0 = rf(flagSet)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*pflag.FlagSet) error); ok {
+		r1 = rf(flagSet)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetStringFrom provides a mock function with given fields: flagSet
 func (_m *FlagSetInterface) GetStringFrom(flagSet *pflag.FlagSet) (string, error) {
 	ret := _m.Called(flagSet)

--- a/cmd/setConfig.go
+++ b/cmd/setConfig.go
@@ -69,7 +69,15 @@ func (*UtilsStruct) SetConfig(flagSet *pflag.FlagSet) error {
 		if err != nil {
 			return err
 		}
-
+		
+		certKey, err := flagSetUtils.GetStringCertKey(flagSet)
+		if err != nil {
+			return err
+		}
+		certFile, err := flagSetUtils.GetStringCertFile(flagSet)
+		if err != nil {
+			return err
+		}
 		viper.Set("exposeMetricsPort", port)
 
 		configErr := viperUtils.ViperWriteConfigAs(path)
@@ -77,7 +85,8 @@ func (*UtilsStruct) SetConfig(flagSet *pflag.FlagSet) error {
 			log.Error("Error in writing config")
 			return configErr
 		}
-		err = metrics.Run(port)
+
+		err = metrics.Run(port, certFile, certKey)
 		if err != nil {
 			logrus.Errorf("failed to start metrics http server: %s", err)
 		}
@@ -135,6 +144,8 @@ func init() {
 		LogLevel           string
 		GasLimitMultiplier float32
 		ExposeMetrics      string
+		CertFile	   	   string
+		CertKey	   		   string
 	)
 	setConfig.Flags().StringVarP(&Provider, "provider", "p", "", "provider name")
 	setConfig.Flags().Float32VarP(&GasMultiplier, "gasmultiplier", "g", -1, "gas multiplier value")
@@ -144,5 +155,7 @@ func init() {
 	setConfig.Flags().StringVarP(&LogLevel, "logLevel", "", "", "log level")
 	setConfig.Flags().Float32VarP(&GasLimitMultiplier, "gasLimit", "", -1, "gas limit percentage increase")
 	setConfig.Flags().StringVarP(&ExposeMetrics, "exposeMetrics", "", "", "port number")
+	setConfig.Flags().StringVarP(&CertFile, "certFile", "", "", "ssl certificate path")
+	setConfig.Flags().StringVarP(&CertKey, "certKey", "", "", "ssl certificate key path")
 
 }

--- a/cmd/setConfig_test.go
+++ b/cmd/setConfig_test.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"errors"
-	"github.com/spf13/pflag"
-	"github.com/stretchr/testify/mock"
 	"razor/cmd/mocks"
 	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestSetConfig(t *testing.T) {
@@ -33,6 +34,10 @@ func TestSetConfig(t *testing.T) {
 		isFlagPassed          bool
 		port                  string
 		portErr               error
+		certFile			  string
+		certFileErr			  error
+		certKey 			  string
+		certKeyErr			  error
 	}
 	tests := []struct {
 		name    string
@@ -280,6 +285,8 @@ func TestSetConfig(t *testing.T) {
 			flagSetUtilsMock.On("GetStringLogLevel", flagSet).Return(tt.args.logLevel, tt.args.logLevelErr)
 			flagSetUtilsMock.On("GetFloat32GasLimit", flagSet).Return(tt.args.gasLimitMultiplier, tt.args.gasLimitMultiplierErr)
 			flagSetUtilsMock.On("GetStringExposeMetrics", flagSet).Return(tt.args.port, tt.args.portErr)
+			flagSetUtilsMock.On("GetStringCertFile", flagSet).Return(tt.args.certFile, tt.args.certFileErr)
+			flagSetUtilsMock.On("GetStringCertKey", flagSet).Return(tt.args.certKey, tt.args.certKeyErr)
 			utilsMock.On("IsFlagPassed", mock.Anything).Return(tt.args.isFlagPassed)
 			utilsMock.On("GetConfigFilePath").Return(tt.args.path, tt.args.pathErr)
 			viperMock.On("ViperWriteConfigAs", mock.AnythingOfType("string")).Return(tt.args.configErr)

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -944,6 +944,16 @@ func (flagSetUtils FLagSetUtils) GetStringExposeMetrics(flagSet *pflag.FlagSet) 
 	return flagSet.GetString("exposeMetrics")
 }
 
+//This function is used to check if CertFile  is passed or not
+func (flagSetUtils FLagSetUtils) GetStringCertFile(flagSet *pflag.FlagSet) (string, error) {
+	return flagSet.GetString("certFile")
+}
+
+//This function is used to check if CertFile  is passed or not
+func (flagSetUtils FLagSetUtils) GetStringCertKey(flagSet *pflag.FlagSet) (string, error) {
+	return flagSet.GetString("certKey")
+}
+
 //This function returns the accounts
 func (keystoreUtils KeystoreUtils) Accounts(path string) []ethAccounts.Account {
 	ks := keystore.NewKeyStore(path, keystore.StandardScryptN, keystore.StandardScryptP)

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -12,12 +12,17 @@ var (
 )
 
 //Run runs metrics http server
-func Run(port string) error {
+func Run(port string, certFile string, certKey string) error {
 	portNumber := ":" + port
 	logrus.Infof("Starting http server to serve metrics at port '%s', endpoint '%s'", portNumber, endpoint)
 
 	http.Handle(endpoint, promhttp.Handler())
 
-	// start an http server using the mux server
-	return http.ListenAndServe(portNumber, nil)
+	if certFile != "" && certKey != ""{
+		// start an https server using the mux server
+		return http.ListenAndServeTLS(portNumber, certFile, certKey, nil)	
+	}else{
+		// start an http server using the mux server
+		return http.ListenAndServe(portNumber, nil)
+	}	
 }


### PR DESCRIPTION
# Description

Fixes #755

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

1. Generate self signed SSL for localhost:
    1. Create private key and CSR
    `openssl req  -new  -newkey rsa:2048  -nodes  -keyout localhost.key  -out localhost.csr`
    2. Generate Certificate 
    `openssl  x509  -req  -days 365  -in localhost.csr  -signkey localhost.key  -out localhost.crt`
 2. Pass Certificate and keyFile path as flag
     `razor setConfig --exposeMetrics 2112 --certFile /cert/file/path/localhost.crt --certKey key/file/path/localhost.key`
3. Visit https://localhost:2112/metrics# Checklist:
