### PR TITLE
Fixed upper limit and buffer difference in getDelayedState

### DIFF
--- a/utils/common.go
+++ b/utils/common.go
@@ -43,7 +43,7 @@ func (*UtilsStruct) GetDelayedState(client *ethclient.Client, buffer int32) (int
 	blockTime := uint64(block.Time)
 	lowerLimit := (core.StateLength * uint64(buffer)) / 100
 	upperLimit := core.StateLength - (core.StateLength*uint64(buffer))/100
-	if blockTime%(core.StateLength) > upperLimit+stateBuffer || blockTime%(core.StateLength) < lowerLimit+stateBuffer {
+	if blockTime%(core.StateLength) > upperLimit-stateBuffer || blockTime%(core.StateLength) < lowerLimit+stateBuffer {
 		return -1, nil
 	}
 	state := blockTime / core.StateLength


### PR DESCRIPTION
# Description

- The upper limit and buffer difference in getDelayedState is fixed.

Fixes #782 