### PR TITLE
dataTypes updated

### DIFF
--- a/cmd/initiateWithdraw_test.go
+++ b/cmd/initiateWithdraw_test.go
@@ -33,7 +33,7 @@ func TestHandleUnstakeLock(t *testing.T) {
 		stateErr                 error
 		lock                     types.Locks
 		lockErr                  error
-		withdrawReleasePeriod    uint8
+		withdrawReleasePeriod    uint16
 		withdrawReleasePeriodErr error
 		txnOpts                  *bind.TransactOpts
 		epoch                    uint32

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -91,7 +91,7 @@ type UtilsInterface interface {
 	GetStakedToken(client *ethclient.Client, address common.Address) *bindings.StakedToken
 	ConvertSRZRToRZR(sAmount *big.Int, currentStake *big.Int, totalSupply *big.Int) *big.Int
 	ConvertRZRToSRZR(sAmount *big.Int, currentStake *big.Int, totalSupply *big.Int) (*big.Int, error)
-	GetWithdrawInitiationPeriod(client *ethclient.Client) (uint8, error)
+	GetWithdrawInitiationPeriod(client *ethclient.Client) (uint16, error)
 	GetCollections(client *ethclient.Client) ([]bindings.StructsCollection, error)
 	GetInfluenceSnapshot(client *ethclient.Client, stakerId uint32, epoch uint32) (*big.Int, error)
 	GetStakerId(client *ethclient.Client, address string) (uint32, error)

--- a/cmd/mocks/utils_interface.go
+++ b/cmd/mocks/utils_interface.go
@@ -1158,14 +1158,14 @@ func (_m *UtilsInterface) GetVoteValue(client *ethclient.Client, epoch uint32, s
 }
 
 // GetWithdrawInitiationPeriod provides a mock function with given fields: client
-func (_m *UtilsInterface) GetWithdrawInitiationPeriod(client *ethclient.Client) (uint8, error) {
+func (_m *UtilsInterface) GetWithdrawInitiationPeriod(client *ethclient.Client) (uint16, error) {
 	ret := _m.Called(client)
 
-	var r0 uint8
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) uint8); ok {
+	var r0 uint16
+	if rf, ok := ret.Get(0).(func(*ethclient.Client) uint16); ok {
 		r0 = rf(client)
 	} else {
-		r0 = ret.Get(0).(uint8)
+		r0 = ret.Get(0).(uint16)
 	}
 
 	var r1 error

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -237,7 +237,7 @@ func (u Utils) ConvertRZRToSRZR(sAmount *big.Int, currentStake *big.Int, totalSu
 }
 
 //This function returns the withdraw initiation period
-func (u Utils) GetWithdrawInitiationPeriod(client *ethclient.Client) (uint8, error) {
+func (u Utils) GetWithdrawInitiationPeriod(client *ethclient.Client) (uint16, error) {
 	return utilsInterface.GetWithdrawInitiationPeriod(client)
 }
 

--- a/utils/interface.go
+++ b/utils/interface.go
@@ -101,7 +101,7 @@ type Utils interface {
 	GetStakerId(client *ethclient.Client, address string) (uint32, error)
 	GetNumberOfStakers(client *ethclient.Client) (uint32, error)
 	GetLock(client *ethclient.Client, address string, stakerId uint32, lockType uint8) (types.Locks, error)
-	GetWithdrawInitiationPeriod(client *ethclient.Client) (uint8, error)
+	GetWithdrawInitiationPeriod(client *ethclient.Client) (uint16, error)
 	GetMaxCommission(client *ethclient.Client) (uint8, error)
 	GetEpochLimitForUpdateCommission(client *ethclient.Client) (uint16, error)
 	GetVoteManagerWithOpts(client *ethclient.Client) (*bindings.VoteManager, bind.CallOpts)
@@ -251,8 +251,7 @@ type StakeManagerUtils interface {
 	Locks(client *ethclient.Client, address common.Address, address1 common.Address, lockType uint8) (types.Locks, error)
 	MaxCommission(client *ethclient.Client) (uint8, error)
 	EpochLimitForUpdateCommission(client *ethclient.Client) (uint16, error)
-	WithdrawInitiationPeriod(client *ethclient.Client) (uint8, error)
-	WithdrawLockPeriod(client *ethclient.Client) (uint8, error)
+	WithdrawInitiationPeriod(client *ethclient.Client) (uint16, error)
 }
 
 type AssetManagerUtils interface {

--- a/utils/mocks/stake_manager_utils.go
+++ b/utils/mocks/stake_manager_utils.go
@@ -170,35 +170,14 @@ func (_m *StakeManagerUtils) MinSafeRazor(client *ethclient.Client) (*big.Int, e
 }
 
 // WithdrawInitiationPeriod provides a mock function with given fields: client
-func (_m *StakeManagerUtils) WithdrawInitiationPeriod(client *ethclient.Client) (uint8, error) {
+func (_m *StakeManagerUtils) WithdrawInitiationPeriod(client *ethclient.Client) (uint16, error) {
 	ret := _m.Called(client)
 
-	var r0 uint8
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) uint8); ok {
+	var r0 uint16
+	if rf, ok := ret.Get(0).(func(*ethclient.Client) uint16); ok {
 		r0 = rf(client)
 	} else {
-		r0 = ret.Get(0).(uint8)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(*ethclient.Client) error); ok {
-		r1 = rf(client)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// WithdrawLockPeriod provides a mock function with given fields: client
-func (_m *StakeManagerUtils) WithdrawLockPeriod(client *ethclient.Client) (uint8, error) {
-	ret := _m.Called(client)
-
-	var r0 uint8
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) uint8); ok {
-		r0 = rf(client)
-	} else {
-		r0 = ret.Get(0).(uint8)
+		r0 = ret.Get(0).(uint16)
 	}
 
 	var r1 error

--- a/utils/mocks/utils.go
+++ b/utils/mocks/utils.go
@@ -1709,14 +1709,14 @@ func (_m *Utils) GetVoteValue(client *ethclient.Client, epoch uint32, stakerId u
 }
 
 // GetWithdrawInitiationPeriod provides a mock function with given fields: client
-func (_m *Utils) GetWithdrawInitiationPeriod(client *ethclient.Client) (uint8, error) {
+func (_m *Utils) GetWithdrawInitiationPeriod(client *ethclient.Client) (uint16, error) {
 	ret := _m.Called(client)
 
-	var r0 uint8
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) uint8); ok {
+	var r0 uint16
+	if rf, ok := ret.Get(0).(func(*ethclient.Client) uint16); ok {
 		r0 = rf(client)
 	} else {
-		r0 = ret.Get(0).(uint8)
+		r0 = ret.Get(0).(uint16)
 	}
 
 	var r1 error

--- a/utils/stake.go
+++ b/utils/stake.go
@@ -121,9 +121,9 @@ func (*UtilsStruct) GetLock(client *ethclient.Client, address string, stakerId u
 	return locks, nil
 }
 
-func (*UtilsStruct) GetWithdrawInitiationPeriod(client *ethclient.Client) (uint8, error) {
+func (*UtilsStruct) GetWithdrawInitiationPeriod(client *ethclient.Client) (uint16, error) {
 	var (
-		withdrawReleasePeriod uint8
+		withdrawReleasePeriod uint16
 		err                   error
 	)
 	err = retry.Do(

--- a/utils/stake_test.go
+++ b/utils/stake_test.go
@@ -446,13 +446,13 @@ func TestGetWithdrawReleasePeriod(t *testing.T) {
 	var client *ethclient.Client
 
 	type args struct {
-		withdrawReleasePeriod    uint8
+		withdrawReleasePeriod    uint16
 		withdrawReleasePeriodErr error
 	}
 	tests := []struct {
 		name    string
 		args    args
-		want    uint8
+		want    uint16
 		wantErr bool
 	}{
 		{

--- a/utils/struct-utils.go
+++ b/utils/struct-utils.go
@@ -56,14 +56,9 @@ func (b BlockManagerStruct) GetBlockIndexToBeConfirmed(client *ethclient.Client)
 	return blockManager.BlockIndexToBeConfirmed(&opts)
 }
 
-func (s StakeManagerStruct) WithdrawInitiationPeriod(client *ethclient.Client) (uint8, error) {
+func (s StakeManagerStruct) WithdrawInitiationPeriod(client *ethclient.Client) (uint16, error) {
 	stakeManager, opts := UtilsInterface.GetStakeManagerWithOpts(client)
 	return stakeManager.WithdrawInitiationPeriod(&opts)
-}
-
-func (s StakeManagerStruct) WithdrawLockPeriod(client *ethclient.Client) (uint8, error) {
-	stakeManager, opts := UtilsInterface.GetStakeManagerWithOpts(client)
-	return stakeManager.WithdrawLockPeriod(&opts)
 }
 
 func (a AssetManagerStruct) GetNumJobs(client *ethclient.Client) (uint16, error) {


### PR DESCRIPTION
# Description

- WithdrawInitiationPeriod updated to uint16
- UnstakeLockPeriod and WithdrawLockPeriod are fetched from locks mapping which is already uint256.
- Removed WithdrawLockPeriod from struct-utils as it is not used anywhere.

Note :

- The build will fail as we don't have npm release for v1-audit-feedback contracts. 
- Merge it after merging #805 as there are few changes in reveal too. 

Fixes #806 