### PR TITLE
added check for nil values in CreateMerkle

### DIFF
--- a/utils/merkle.go
+++ b/utils/merkle.go
@@ -6,9 +6,11 @@ import (
 )
 
 func (*MerkleTreeStruct) CreateMerkle(values []*big.Int) [][][]byte {
+	if len(values) == 0 {
+		return [][][]byte{}
+	}
 	var tree [][][]byte
 	var leaves [][]byte
-
 	for i := 0; i < len(values); i++ {
 		leaves = append(leaves, solsha3.SoliditySHA3([]string{"uint256"}, []interface{}{values[i]}))
 	}

--- a/utils/merkle_test.go
+++ b/utils/merkle_test.go
@@ -50,6 +50,20 @@ func TestMerkleTreeStructCreateMerkle(t *testing.T) {
 			},
 			want: [][][]byte{{{41, 13, 236, 217, 84, 139, 98, 168, 214, 3, 69, 169, 136, 56, 111, 200, 75, 166, 188, 149, 72, 64, 8, 246, 54, 47, 147, 22, 14, 243, 229, 99}}},
 		},
+		{
+			name: "Test 6: When CreateMerkle() contains no values",
+			args: args{
+				values: []*big.Int{},
+			},
+			want: [][][]byte{},
+		},
+		{
+			name: "Test 7: When CreateMerkle() contains nil values",
+			args: args{
+				values: nil,
+			},
+			want: [][][]byte{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

- Added a check in createMerkle() for nil values.
- Added a length check of values as for checking nil values 
- Could not use if values == nil {}, as it still goes in infinite loop if values are empty array in CreateMerkle()
- Now empty tree if returned if the values are nil or empty array

Fixes #787 
