### PR TITLE
Fix: If medians proposed are empty all stakers stop

### DIFF
--- a/cmd/dispute.go
+++ b/cmd/dispute.go
@@ -131,7 +131,7 @@ func (*UtilsStruct) HandleDispute(client *ethclient.Client, config types.Configu
 			log.Warn("BLOCK NOT MATCHING WITH LOCAL CALCULATIONS.")
 			log.Debug("Block Values: ", proposedBlock.Medians)
 			log.Debug("Local Calculations: ", medians)
-			if proposedBlock.Valid {
+			if proposedBlock.Valid && len(proposedBlock.Ids) != 0 && len(proposedBlock.Medians) != 0 {
 				// median locally calculated: [100, 200, 300, 500]   median proposed: [100, 230, 300, 500]
 				// ids [1, 2, 3, 4]
 				// Sorted revealed values would be the vote values for the wrong median, here 230

--- a/cmd/dispute_test.go
+++ b/cmd/dispute_test.go
@@ -437,6 +437,28 @@ func TestHandleDispute(t *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			name: "Test 16: When HandleDispute function executes successfully and medians proposed are empty",
+			args: args{
+				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
+				biggestStakeId:         2,
+				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
+				revealedCollectionIds:  []uint16{1},
+				revealedDataMaps: &types.RevealedDataMaps{
+					SortedRevealedValues: nil,
+					VoteWeights:          nil,
+					InfluenceSum:         nil,
+				},
+				proposedBlock: bindings.StructsBlock{
+					Medians:      []*big.Int{},
+					Valid:        true,
+					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
+				},
+				disputeErr: nil,
+			},
+			want: nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

- Added a condition in median check dispute if medians proposed are empty . It was thrwoing error due to this line https://github.com/razor-network/razor-go/blob/371032601cbe5823b179e6e036e46152ac54a2ff/cmd/dispute.go#L138
- Added test for this above condition

Fixes #808 