### PR TITLE
disputeBiggestStakerId hotfix

### DIFF
--- a/cmd/dispute.go
+++ b/cmd/dispute.go
@@ -68,6 +68,10 @@ func (*UtilsStruct) HandleDispute(client *ethclient.Client, config types.Configu
 
 		//blockIndex is index of blockId in sortedProposedBlock
 		blockIndex := utils.IndexOf(sortedProposedBlockIds, uint32(blockId))
+		if blockIndex == -1 {
+			log.Error("Block is not present in SortedProposedBlockIds array")
+			continue
+		}
 
 		// Biggest staker dispute
 		if proposedBlock.BiggestStake.Cmp(biggestStake) != 0 && proposedBlock.Valid {

--- a/cmd/dispute_test.go
+++ b/cmd/dispute_test.go
@@ -172,7 +172,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 1: When HandleDispute function executes successfully",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
@@ -194,7 +194,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 2: When HandleDispute function executes successfully when there is no dispute case",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				proposedBlock: bindings.StructsBlock{
@@ -219,7 +219,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 4: When there is an error in getting proposedBlock",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				proposedBlockErr:       errors.New("proposedBlock error"),
 				disputeErr:             nil,
 			},
@@ -228,7 +228,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 5: When there is a case of Dispute but block is already disputed",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				proposedBlock: bindings.StructsBlock{
@@ -241,7 +241,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 6: When HandleDispute function executes successfully when there is a biggest influence dispute case",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				proposedBlock: bindings.StructsBlock{
@@ -258,7 +258,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 7: When there is an error in getting biggestInfluenceAndId",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				biggestStakeErr:        errors.New("biggestInfluenceAndIdErr"),
 				proposedBlock: bindings.StructsBlock{
 					Medians:      []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
@@ -275,7 +275,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 8: When DisputeBiggestStakeProposed transaction fails",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				proposedBlock: bindings.StructsBlock{
@@ -292,7 +292,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 9: When there is an error in getting medians",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				mediansErr:             errors.New("error in getting medians"),
@@ -302,7 +302,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 10: When there is an error in fetching Ids from CheckDisputeForIds",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
@@ -325,7 +325,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 11: When idDisputeTxn is not nil",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
@@ -348,7 +348,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 12: When it is a median dispute case and error in getting leafId",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
@@ -373,7 +373,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 13: When there is an error in dispute",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
@@ -398,7 +398,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 14: When there is a biggest influence dispute case but there is an error in storing bountyId",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				proposedBlock: bindings.StructsBlock{
@@ -416,7 +416,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 15: When there is a idsDispute case but there is an error in storing bountyId",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
@@ -440,7 +440,7 @@ func TestHandleDispute(t *testing.T) {
 		{
 			name: "Test 16: When HandleDispute function executes successfully and medians proposed are empty",
 			args: args{
-				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				sortedProposedBlockIds: []uint32{3, 1, 2, 0, 4},
 				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				biggestStakeId:         2,
 				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
@@ -452,6 +452,28 @@ func TestHandleDispute(t *testing.T) {
 				},
 				proposedBlock: bindings.StructsBlock{
 					Medians:      []*big.Int{},
+					Valid:        true,
+					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
+				},
+				disputeErr: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "Test 17: When there is a case of blockIndex = -1",
+			args: args{
+				sortedProposedBlockIds: []uint32{3, 1, 2, 5, 4},
+				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
+				biggestStakeId:         2,
+				medians:                []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
+				revealedCollectionIds:  []uint16{1},
+				revealedDataMaps: &types.RevealedDataMaps{
+					SortedRevealedValues: nil,
+					VoteWeights:          nil,
+					InfluenceSum:         nil,
+				},
+				proposedBlock: bindings.StructsBlock{
+					Medians:      []*big.Int{big.NewInt(6901548), big.NewInt(498307)},
 					Valid:        true,
 					BiggestStake: big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
 				},


### PR DESCRIPTION
# Description

When staker proposes incorrect biggestStakerId, there is a chance that proposed block does not get added to `SortedProposedBlockIds[]`.

Ref - https://github.com/razor-network/contracts/blob/v1-audit-feedback/contracts/Core/BlockManager.sol#L184

So we added a check of `blockIndex ==-1`
Fixes #809

