### PR TITLE
Fix: config-utils - write generic function to get config var instead of explicit functions to save on code repitition

### DIFF
--- a/cmd/cmd-utils.go
+++ b/cmd/cmd-utils.go
@@ -19,11 +19,15 @@ func (*UtilsStruct) GetEpochAndState(client *ethclient.Client) (uint32, int64, e
 	if err != nil {
 		return 0, 0, err
 	}
-	bufferPercent, err := cmdUtils.GetBufferPercent()
+	bufferPercentString, err := cmdUtils.GetConfig("buffer")
 	if err != nil {
 		return 0, 0, err
 	}
-	state, err := razorUtils.GetDelayedState(client, bufferPercent)
+	bufferPercent, err := stringUtils.ParseInt(bufferPercentString)
+	if err != nil {
+		return 0, 0, err
+	}
+	state, err := razorUtils.GetDelayedState(client, int32(bufferPercent))
 	if err != nil {
 		return 0, 0, err
 	}

--- a/cmd/cmd-utils_test.go
+++ b/cmd/cmd-utils_test.go
@@ -16,13 +16,15 @@ func TestGetEpochAndState(t *testing.T) {
 	var client *ethclient.Client
 
 	type args struct {
-		epoch            uint32
-		epochErr         error
-		bufferPercent    int32
-		bufferPercentErr error
-		state            int64
-		stateErr         error
-		stateName        string
+		epoch                  uint32
+		epochErr               error
+		bufferPercentString    string
+		bufferPercentStringErr error
+		bufferPercent          int64
+		bufferPercentErr       error
+		state                  int64
+		stateErr               error
+		stateName              string
 	}
 	tests := []struct {
 		name      string
@@ -34,10 +36,11 @@ func TestGetEpochAndState(t *testing.T) {
 		{
 			name: "Test 1: When GetEpochAndState function executes successfully",
 			args: args{
-				epoch:         4,
-				bufferPercent: 20,
-				state:         0,
-				stateName:     "commit",
+				epoch:               4,
+				bufferPercentString: "20",
+				bufferPercent:       20,
+				state:               0,
+				stateName:           "commit",
 			},
 			wantEpoch: 4,
 			wantState: 0,
@@ -46,33 +49,48 @@ func TestGetEpochAndState(t *testing.T) {
 		{
 			name: "Test 2: When there is an error in getting epoch",
 			args: args{
-				epochErr:      errors.New("epoch error"),
-				bufferPercent: 20,
-				state:         0,
-				stateName:     "commit",
+				epochErr:            errors.New("epoch error"),
+				bufferPercentString: "20",
+				bufferPercent:       20,
+				state:               0,
+				stateName:           "commit",
 			},
 			wantEpoch: 0,
 			wantState: 0,
 			wantErr:   errors.New("epoch error"),
 		},
 		{
-			name: "Test 3: When there is an error in getting bufferPercent",
+			name: "Test 3: When there is an error in getting getConfig",
 			args: args{
-				epoch:            4,
-				bufferPercentErr: errors.New("bufferPercent error"),
-				state:            0,
-				stateName:        "commit",
+				epoch:                  4,
+				bufferPercentStringErr: errors.New("bufferPercentString error"),
+				state:                  0,
+				stateName:              "commit",
+			},
+			wantEpoch: 0,
+			wantState: 0,
+			wantErr:   errors.New("bufferPercentString error"),
+		},
+		{
+			name: "Test 4: When there is an error in parsing int",
+			args: args{
+				epoch:               4,
+				bufferPercentString: "20",
+				bufferPercentErr:    errors.New("bufferPercent error"),
+				state:               0,
+				stateName:           "commit",
 			},
 			wantEpoch: 0,
 			wantState: 0,
 			wantErr:   errors.New("bufferPercent error"),
 		},
 		{
-			name: "Test 4: When there is an error in getting state",
+			name: "Test 5: When there is an error in getting state",
 			args: args{
-				epoch:         4,
-				bufferPercent: 20,
-				stateErr:      errors.New("state error"),
+				epoch:               4,
+				bufferPercentString: "20",
+				bufferPercent:       20,
+				stateErr:            errors.New("state error"),
 			},
 			wantEpoch: 0,
 			wantState: 0,
@@ -85,13 +103,16 @@ func TestGetEpochAndState(t *testing.T) {
 			utilsMock := new(mocks.UtilsInterface)
 			cmdUtilsMock := new(mocks.UtilsCmdInterface)
 			utilsPkgMock := new(mocks2.Utils)
+			stringMock := new(mocks.StringInterface)
 
 			razorUtils = utilsMock
 			cmdUtils = cmdUtilsMock
 			utils.UtilsInterface = utilsPkgMock
+			stringUtils = stringMock
 
 			utilsMock.On("GetEpoch", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.epoch, tt.args.epochErr)
-			cmdUtilsMock.On("GetBufferPercent").Return(tt.args.bufferPercent, tt.args.bufferPercentErr)
+			cmdUtilsMock.On("GetConfig", "buffer").Return(tt.args.bufferPercentString, tt.args.bufferPercentStringErr)
+			stringMock.On("ParseInt", tt.args.bufferPercentString).Return(tt.args.bufferPercent, tt.args.bufferPercentErr)
 			utilsMock.On("GetDelayedState", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("int32")).Return(tt.args.state, tt.args.stateErr)
 			utilsPkgMock.On("GetStateName", mock.AnythingOfType("int64")).Return(tt.args.stateName)
 

--- a/cmd/config-utils.go
+++ b/cmd/config-utils.go
@@ -76,6 +76,7 @@ func (*UtilsStruct) GetConfigData() (types.Configurations, error) {
 	return config, nil
 }
 
+//This function returns the config value in form of string taking configType as input
 func (*UtilsStruct) GetConfig(configType string) (string, error) {
 	switch configType {
 	case "provider":

--- a/cmd/config-utils.go
+++ b/cmd/config-utils.go
@@ -17,129 +17,140 @@ func (*UtilsStruct) GetConfigData() (types.Configurations, error) {
 		LogLevel:           "",
 		GasLimitMultiplier: 0,
 	}
-
-	provider, err := cmdUtils.GetProvider()
+	provider, err := cmdUtils.GetConfig("provider")
 	if err != nil {
 		return config, err
 	}
-	gasMultiplier, err := cmdUtils.GetMultiplier()
+	gasMultiplierString, err := cmdUtils.GetConfig("gasmultiplier")
 	if err != nil {
 		return config, err
 	}
-	bufferPercent, err := cmdUtils.GetBufferPercent()
+	bufferPercentString, err := cmdUtils.GetConfig("buffer")
 	if err != nil {
 		return config, err
 	}
-	waitTime, err := cmdUtils.GetWaitTime()
+	waitTimeString, err := cmdUtils.GetConfig("wait")
 	if err != nil {
 		return config, err
 	}
-	gasPrice, err := cmdUtils.GetGasPrice()
+	gasPriceString, err := cmdUtils.GetConfig("gasprice")
 	if err != nil {
 		return config, err
 	}
-	logLevel, err := cmdUtils.GetLogLevel()
+	logLevel, err := cmdUtils.GetConfig("logLevel")
 	if err != nil {
 		return config, err
 	}
-	gasLimit, err := cmdUtils.GetGasLimit()
+	gasLimitString, err := cmdUtils.GetConfig("gasLimit")
 	if err != nil {
 		return config, err
 	}
 	config.Provider = provider
-	config.GasMultiplier = gasMultiplier
-	config.BufferPercent = bufferPercent
-	config.WaitTime = waitTime
-	config.GasPrice = gasPrice
+	gasMultiplier, err := stringUtils.ParseFloat(gasMultiplierString)
+	if err != nil {
+		return config, err
+	}
+	config.GasMultiplier = float32(gasMultiplier)
+	bufferPercent, err := stringUtils.ParseInt(bufferPercentString)
+	if err != nil {
+		return config, err
+	}
+	config.BufferPercent = int32(bufferPercent)
+	waitTime, err := stringUtils.ParseInt(waitTimeString)
+	if err != nil {
+		return config, err
+	}
+	config.WaitTime = int32(waitTime)
+	gasPrice, err := stringUtils.ParseInt(gasPriceString)
+	if err != nil {
+		return config, err
+	}
+	config.GasPrice = int32(gasPrice)
 	config.LogLevel = logLevel
-	config.GasLimitMultiplier = gasLimit
+	gasLimit, err := stringUtils.ParseFloat(gasLimitString)
+	if err != nil {
+		return config, err
+	}
+	config.GasLimitMultiplier = float32(gasLimit)
 
 	return config, nil
 }
 
-//This function returns the provider
-func (*UtilsStruct) GetProvider() (string, error) {
-	provider, err := flagSetUtils.GetRootStringProvider()
-	if err != nil {
-		return "", err
-	}
-	if provider == "" {
-		provider = viper.GetString("provider")
-	}
-	if !strings.HasPrefix(provider, "https") {
-		log.Warn("You are not using a secure RPC URL. Switch to an https URL instead to be safe.")
-	}
-	return provider, nil
-}
+func (*UtilsStruct) GetConfig(configType string) (string, error) {
+	switch configType {
+	case "provider":
+		provider, err := flagSetUtils.GetRootStringConfig(configType)
+		if err != nil {
+			return "", err
+		}
+		if provider == "" {
+			provider = viper.GetString(configType)
+		}
+		if !strings.HasPrefix(provider, "https") {
+			log.Warn("You are not using a secure RPC URL. Switch to an https URL instead to be safe.")
+		}
+		return provider, nil
 
-//This function returns the multiplier
-func (*UtilsStruct) GetMultiplier() (float32, error) {
-	gasMultiplier, err := flagSetUtils.GetRootFloat32GasMultiplier()
-	if err != nil {
-		return 1, err
-	}
-	if gasMultiplier == -1 {
-		gasMultiplier = float32(viper.GetFloat64("gasmultiplier"))
-	}
-	return gasMultiplier, nil
-}
+	case "gasmultiplier":
+		gasMultiplier, err := flagSetUtils.GetRootStringConfig(configType)
+		if err != nil {
+			return "1", err
+		}
+		if gasMultiplier == "-1" {
+			gasMultiplier = viper.GetString(configType)
+		}
+		return gasMultiplier, nil
 
-//This function returns the buffer percent
-func (*UtilsStruct) GetBufferPercent() (int32, error) {
-	bufferPercent, err := flagSetUtils.GetRootInt32Buffer()
-	if err != nil {
-		return 30, err
-	}
-	if bufferPercent == 0 {
-		bufferPercent = viper.GetInt32("buffer")
-	}
-	return bufferPercent, nil
-}
+	case "buffer":
+		bufferPercent, err := flagSetUtils.GetRootStringConfig(configType)
+		if err != nil {
+			return "30", err
+		}
+		if bufferPercent == "0" {
+			bufferPercent = viper.GetString(configType)
+		}
+		return bufferPercent, nil
 
-//This function returns the wait time
-func (*UtilsStruct) GetWaitTime() (int32, error) {
-	waitTime, err := flagSetUtils.GetRootInt32Wait()
-	if err != nil {
-		return 3, err
-	}
-	if waitTime == -1 {
-		waitTime = viper.GetInt32("wait")
-	}
-	return waitTime, nil
-}
+	case "wait":
+		waitTime, err := flagSetUtils.GetRootStringConfig(configType)
+		if err != nil {
+			return "3", err
+		}
+		if waitTime == "-1" {
+			waitTime = viper.GetString(configType)
+		}
+		return waitTime, nil
 
-//This function returns the gas price
-func (*UtilsStruct) GetGasPrice() (int32, error) {
-	gasPrice, err := flagSetUtils.GetRootInt32GasPrice()
-	if err != nil {
-		return 0, err
-	}
-	if gasPrice == -1 {
-		gasPrice = viper.GetInt32("gasprice")
-	}
-	return gasPrice, nil
-}
+	case "gasprice":
+		gasPrice, err := flagSetUtils.GetRootStringConfig(configType)
+		if err != nil {
+			return "0", err
+		}
+		if gasPrice == "-1" {
+			gasPrice = viper.GetString(configType)
+		}
+		return gasPrice, nil
 
-//This function returns the log level
-func (*UtilsStruct) GetLogLevel() (string, error) {
-	logLevel, err := flagSetUtils.GetRootStringLogLevel()
-	if err != nil {
-		return "", err
-	}
-	if logLevel == "" {
-		logLevel = viper.GetString("logLevel")
-	}
-	return logLevel, nil
-}
+	case "logLevel":
+		logLevel, err := flagSetUtils.GetRootStringConfig(configType)
+		if err != nil {
+			return "", err
+		}
+		if logLevel == "" {
+			logLevel = viper.GetString(configType)
+		}
+		return logLevel, nil
 
-//This function returns the gas limit
-func (*UtilsStruct) GetGasLimit() (float32, error) {
-	gasLimit, err := flagSetUtils.GetRootFloat32GasLimit()
-	if err != nil {
-		return -1, err
+	case "gasLimit":
+		gasLimit, err := flagSetUtils.GetRootStringConfig(configType)
+		if err != nil {
+			return "-1", err
+		}
+		if gasLimit == "-1" {
+			gasLimit = viper.GetString(configType)
+		}
+		return gasLimit, nil
+
 	}
-	if gasLimit == -1 {
-		gasLimit = float32(viper.GetFloat64("gasLimit"))
-	}
-	return gasLimit, nil
+	return "", nil
 }

--- a/cmd/config-utils_test.go
+++ b/cmd/config-utils_test.go
@@ -28,20 +28,30 @@ func TestGetConfigData(t *testing.T) {
 	}
 
 	type args struct {
-		provider         string
-		providerErr      error
-		gasMultiplier    float32
-		gasMultiplierErr error
-		bufferPercent    int32
-		bufferPercentErr error
-		waitTime         int32
-		waitTimeErr      error
-		gasPrice         int32
-		gasPriceErr      error
-		logLevel         string
-		logLevelErr      error
-		gasLimit         float32
-		gasLimitErr      error
+		provider               string
+		providerErr            error
+		gasMultiplierString    string
+		gasMultiplierStringErr error
+		gasMultiplier          float64
+		gasMultiplierErr       error
+		bufferPercentString    string
+		bufferPercentStringErr error
+		bufferPercent          int64
+		bufferPercentErr       error
+		waitTimeString         string
+		waitTimeStringErr      error
+		waitTime               int64
+		waitTimeErr            error
+		gasPriceString         string
+		gasPriceStringErr      error
+		gasPrice               int64
+		gasPriceErr            error
+		logLevel               string
+		logLevelErr            error
+		gasLimitString         string
+		gasLimitStringErr      error
+		gasLimit               float64
+		gasLimitErr            error
 	}
 	tests := []struct {
 		name    string
@@ -52,12 +62,16 @@ func TestGetConfigData(t *testing.T) {
 		{
 			name: "Test 1: When GetConfigData function executes successfully",
 			args: args{
-				provider:      "",
-				gasMultiplier: 1,
-				bufferPercent: 20,
-				waitTime:      1,
-				logLevel:      "debug",
-				gasLimit:      3,
+				provider:            "",
+				gasMultiplierString: "1",
+				gasMultiplier:       1,
+				bufferPercentString: "20",
+				bufferPercent:       20,
+				waitTimeString:      "1",
+				waitTime:            1,
+				logLevel:            "debug",
+				gasLimitString:      "3",
+				gasLimit:            3,
 			},
 			want:    configData,
 			wantErr: nil,
@@ -73,7 +87,7 @@ func TestGetConfigData(t *testing.T) {
 		{
 			name: "Test 3: When there is an error in getting gasMultiplier",
 			args: args{
-				gasMultiplierErr: errors.New("gasMultiplier error"),
+				gasMultiplierStringErr: errors.New("gasMultiplier error"),
 			},
 			want:    config,
 			wantErr: errors.New("gasMultiplier error"),
@@ -81,7 +95,7 @@ func TestGetConfigData(t *testing.T) {
 		{
 			name: "Test 4: When there is an error in getting bufferPercent",
 			args: args{
-				bufferPercentErr: errors.New("bufferPercent error"),
+				bufferPercentStringErr: errors.New("bufferPercent error"),
 			},
 			want:    config,
 			wantErr: errors.New("bufferPercent error"),
@@ -89,7 +103,7 @@ func TestGetConfigData(t *testing.T) {
 		{
 			name: "Test 5: When there is an error in getting waitTime",
 			args: args{
-				waitTimeErr: errors.New("waitTime error"),
+				waitTimeStringErr: errors.New("waitTime error"),
 			},
 			want:    config,
 			wantErr: errors.New("waitTime error"),
@@ -97,7 +111,7 @@ func TestGetConfigData(t *testing.T) {
 		{
 			name: "Test 6: When there is an error in getting gasPrice",
 			args: args{
-				gasPriceErr: errors.New("gasPrice error"),
+				gasPriceStringErr: errors.New("gasPrice error"),
 			},
 			want:    config,
 			wantErr: errors.New("gasPrice error"),
@@ -113,24 +127,55 @@ func TestGetConfigData(t *testing.T) {
 		{
 			name: "Test 8: When there is an error in getting gasLimit",
 			args: args{
-				gasLimitErr: errors.New("gasLimit error"),
+				gasLimitStringErr: errors.New("gasLimit error"),
 			},
 			want:    config,
 			wantErr: errors.New("gasLimit error"),
+		},
+		{
+			name: "Test 9: When there is an error in parsing float for gas multiplier",
+			args: args{
+				gasMultiplierErr: errors.New("error in parsing"),
+			},
+			want:    config,
+			wantErr: errors.New("error in parsing"),
+		},
+		{
+			name: "Test 10: When there is an error in parsing int for buffer",
+			args: args{
+				bufferPercentErr: errors.New("error in parsing"),
+			},
+			want:    config,
+			wantErr: errors.New("error in parsing"),
+		},
+		{
+			name: "Test 11: When there is an error in parsing int for waitTime",
+			args: args{
+				waitTimeErr: errors.New("error in parsing"),
+			},
+			want:    config,
+			wantErr: nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmdUtilsMock := new(mocks.UtilsCmdInterface)
+			stringMock := new(mocks.StringInterface)
 			cmdUtils = cmdUtilsMock
+			stringUtils = stringMock
 
-			cmdUtilsMock.On("GetProvider").Return(tt.args.provider, tt.args.providerErr)
-			cmdUtilsMock.On("GetMultiplier").Return(tt.args.gasMultiplier, tt.args.gasMultiplierErr)
-			cmdUtilsMock.On("GetWaitTime").Return(tt.args.waitTime, tt.args.waitTimeErr)
-			cmdUtilsMock.On("GetGasPrice").Return(tt.args.gasPrice, tt.args.gasPriceErr)
-			cmdUtilsMock.On("GetLogLevel").Return(tt.args.logLevel, tt.args.logLevelErr)
-			cmdUtilsMock.On("GetGasLimit").Return(tt.args.gasLimit, tt.args.gasLimitErr)
-			cmdUtilsMock.On("GetBufferPercent").Return(tt.args.bufferPercent, tt.args.bufferPercentErr)
+			cmdUtilsMock.On("GetConfig", "provider").Return(tt.args.provider, tt.args.providerErr)
+			cmdUtilsMock.On("GetConfig", "gasmultiplier").Return(tt.args.gasMultiplierString, tt.args.gasMultiplierStringErr)
+			cmdUtilsMock.On("GetConfig", "wait").Return(tt.args.waitTimeString, tt.args.waitTimeStringErr)
+			cmdUtilsMock.On("GetConfig", "gasprice").Return(tt.args.gasPriceString, tt.args.gasPriceStringErr)
+			cmdUtilsMock.On("GetConfig", "logLevel").Return(tt.args.logLevel, tt.args.logLevelErr)
+			cmdUtilsMock.On("GetConfig", "gasLimit").Return(tt.args.gasLimitString, tt.args.gasLimitStringErr)
+			cmdUtilsMock.On("GetConfig", "buffer").Return(tt.args.bufferPercentString, tt.args.bufferPercentStringErr)
+			stringMock.On("ParseFloat", tt.args.gasMultiplierString).Return(tt.args.gasMultiplier, tt.args.gasMultiplierErr)
+			stringMock.On("ParseInt", tt.args.bufferPercentString).Return(tt.args.bufferPercent, tt.args.bufferPercentErr)
+			stringMock.On("ParseInt", tt.args.waitTimeString).Return(tt.args.waitTime, tt.args.waitTimeErr)
+			stringMock.On("ParseInt", tt.args.gasPriceString).Return(tt.args.gasPrice, tt.args.gasPriceErr)
+			stringMock.On("ParseFloat", tt.args.gasLimitString).Return(tt.args.gasLimit, tt.args.gasLimitErr)
 
 			utils := &UtilsStruct{}
 
@@ -152,413 +197,235 @@ func TestGetConfigData(t *testing.T) {
 	}
 }
 
-func TestGetBufferPercent(t *testing.T) {
+func TestGetConfig(t *testing.T) {
 	type args struct {
-		bufferPercent    int32
-		bufferPercentErr error
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    int32
-		wantErr error
-	}{
-		{
-			name: "Test 1: When getBufferPercent function executes successfully",
-			args: args{
-				bufferPercent: 20,
-			},
-			want:    20,
-			wantErr: nil,
-		},
-		{
-			name: "Test 2: When bufferPercent is 0",
-			args: args{
-				bufferPercent: 0,
-			},
-			want:    0,
-			wantErr: nil,
-		},
-		{
-			name: "Test 3: When there is an error in getting bufferPercent",
-			args: args{
-				bufferPercentErr: errors.New("bufferPercent error"),
-			},
-			want:    30,
-			wantErr: errors.New("bufferPercent error"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			flagSetUtilsMock := new(mocks.FlagSetInterface)
-			flagSetUtils = flagSetUtilsMock
-
-			flagSetUtilsMock.On("GetRootInt32Buffer").Return(tt.args.bufferPercent, tt.args.bufferPercentErr)
-			utils := &UtilsStruct{}
-			got, err := utils.GetBufferPercent()
-			if got != tt.want {
-				t.Errorf("getBufferPercent() got = %v, want %v", got, tt.want)
-			}
-			if err == nil || tt.wantErr == nil {
-				if err != tt.wantErr {
-					t.Errorf("Error for getBufferPercent function, got = %v, want = %v", err, tt.wantErr)
-				}
-			} else {
-				if err.Error() != tt.wantErr.Error() {
-					t.Errorf("Error for getBufferPercent function, got = %v, want = %v", err, tt.wantErr)
-				}
-			}
-		})
-	}
-}
-
-func TestGetGasLimit(t *testing.T) {
-	type args struct {
-		gasLimit    float32
-		gasLimitErr error
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    float32
-		wantErr error
-	}{
-		{
-			name: "Test 1: When getGasLimit function executes successfully",
-			args: args{
-				gasLimit: 4,
-			},
-			want:    4,
-			wantErr: nil,
-		},
-		{
-			name: "Test 2: When gasLimit is -1",
-			args: args{
-				gasLimit: -1,
-			},
-			want:    0,
-			wantErr: nil,
-		},
-		{
-			name: "Test 3: When there is an error in getting gasLimit",
-			args: args{
-				gasLimitErr: errors.New("gasLimit error"),
-			},
-			want:    -1,
-			wantErr: errors.New("gasLimit error"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			flagSetUtilsMock := new(mocks.FlagSetInterface)
-			flagSetUtils = flagSetUtilsMock
-
-			flagSetUtilsMock.On("GetRootFloat32GasLimit").Return(tt.args.gasLimit, tt.args.gasLimitErr)
-			utils := &UtilsStruct{}
-
-			got, err := utils.GetGasLimit()
-			if got != tt.want {
-				t.Errorf("getGasLimit() got = %v, want %v", got, tt.want)
-			}
-			if err == nil || tt.wantErr == nil {
-				if err != tt.wantErr {
-					t.Errorf("Error for getGasLimit function, got = %v, want = %v", err, tt.wantErr)
-				}
-			} else {
-				if err.Error() != tt.wantErr.Error() {
-					t.Errorf("Error for getGasLimit function, got = %v, want = %v", err, tt.wantErr)
-				}
-			}
-		})
-	}
-}
-
-func TestGetGasPrice(t *testing.T) {
-	type args struct {
-		gasPrice    int32
-		gasPriceErr error
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    int32
-		wantErr error
-	}{
-		{
-			name: "Test 1: When getGasPrice function executes successfully",
-			args: args{
-				gasPrice: 1,
-			},
-			want:    1,
-			wantErr: nil,
-		},
-		{
-			name: "Test 2: When gasPrice is -1",
-			args: args{
-				gasPrice: -1,
-			},
-			want:    0,
-			wantErr: nil,
-		},
-		{
-			name: "Test 3: When there is an error in getting gasPrice",
-			args: args{
-				gasPriceErr: errors.New("gasPrice error"),
-			},
-			want:    0,
-			wantErr: errors.New("gasPrice error"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			flagSetUtilsMock := new(mocks.FlagSetInterface)
-			flagSetUtils = flagSetUtilsMock
-
-			flagSetUtilsMock.On("GetRootInt32GasPrice").Return(tt.args.gasPrice, tt.args.gasPriceErr)
-			utils := &UtilsStruct{}
-
-			got, err := utils.GetGasPrice()
-			if got != tt.want {
-				t.Errorf("getGasPrice() got = %v, want %v", got, tt.want)
-			}
-			if err == nil || tt.wantErr == nil {
-				if err != tt.wantErr {
-					t.Errorf("Error for getGasPrice function, got = %v, want = %v", err, tt.wantErr)
-				}
-			} else {
-				if err.Error() != tt.wantErr.Error() {
-					t.Errorf("Error for getGasPrice function, got = %v, want = %v", err, tt.wantErr)
-				}
-			}
-		})
-	}
-}
-
-func TestGetLogLevel(t *testing.T) {
-	type args struct {
-		logLevel    string
-		logLevelErr error
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr error
-	}{
-		{
-			name: "Test 1: When getLogLevel function executes successfully",
-			args: args{
-				logLevel: "debug",
-			},
-			want:    "debug",
-			wantErr: nil,
-		},
-		{
-			name: "Test 2: When logLevel is nil",
-			args: args{
-				logLevel: "",
-			},
-			want:    "",
-			wantErr: nil,
-		},
-		{
-			name: "Test 3: When there is an error in getting logLevel",
-			args: args{
-				logLevelErr: errors.New("logLevel error"),
-			},
-			want:    "",
-			wantErr: errors.New("logLevel error"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			flagSetUtilsMock := new(mocks.FlagSetInterface)
-			flagSetUtils = flagSetUtilsMock
-
-			flagSetUtilsMock.On("GetRootStringLogLevel").Return(tt.args.logLevel, tt.args.logLevelErr)
-			utils := &UtilsStruct{}
-
-			got, err := utils.GetLogLevel()
-			if got != tt.want {
-				t.Errorf("getLogLevel() got = %v, want %v", got, tt.want)
-			}
-			if err == nil || tt.wantErr == nil {
-				if err != tt.wantErr {
-					t.Errorf("Error for getLogLevel function, got = %v, want = %v", err, tt.wantErr)
-				}
-			} else {
-				if err.Error() != tt.wantErr.Error() {
-					t.Errorf("Error for getLogLevel function, got = %v, want = %v", err, tt.wantErr)
-				}
-			}
-		})
-	}
-}
-
-func TestGetMultiplier(t *testing.T) {
-	type args struct {
-		gasMultiplier    float32
+		configType       string
+		provider         string
+		providerErr      error
+		gasMultiplier    string
 		gasMultiplierErr error
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    float32
-		wantErr error
-	}{
-		{
-			name: "Test 1: When getMultiplier function executes successfully",
-			args: args{
-				gasMultiplier: 2,
-			},
-			want:    2,
-			wantErr: nil,
-		},
-		{
-			name: "Test 2: When gasMultiplier is -1",
-			args: args{
-				gasMultiplier: -1,
-			},
-			want:    0,
-			wantErr: nil,
-		},
-		{
-			name: "Test 3: When there is an error in getting gasMultiplier",
-			args: args{
-				gasMultiplierErr: errors.New("gasMultiplier error"),
-			},
-			want:    1,
-			wantErr: errors.New("gasMultiplier error"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			flagSetUtilsMock := new(mocks.FlagSetInterface)
-			flagSetUtils = flagSetUtilsMock
-
-			flagSetUtilsMock.On("GetRootFloat32GasMultiplier").Return(tt.args.gasMultiplier, tt.args.gasMultiplierErr)
-			utils := &UtilsStruct{}
-
-			got, err := utils.GetMultiplier()
-			if got != tt.want {
-				t.Errorf("getMultiplier() got = %v, want %v", got, tt.want)
-			}
-			if err == nil || tt.wantErr == nil {
-				if err != tt.wantErr {
-					t.Errorf("Error for getMultiplier function, got = %v, want = %v", err, tt.wantErr)
-				}
-			} else {
-				if err.Error() != tt.wantErr.Error() {
-					t.Errorf("Error for getMultiplier function, got = %v, want = %v", err, tt.wantErr)
-				}
-			}
-		})
-	}
-}
-
-func TestGetProvider(t *testing.T) {
-	type args struct {
-		provider    string
-		providerErr error
+		bufferPercent    string
+		bufferPercentErr error
+		waitTime         string
+		waitTimeErr      error
+		gasPrice         string
+		gasPriceErr      error
+		logLevel         string
+		logLevelErr      error
+		gasLimit         string
+		gasLimitErr      error
 	}
 	tests := []struct {
 		name    string
 		args    args
 		want    string
-		wantErr error
+		wantErr bool
 	}{
 		{
-			name: "Test 1: When getProvider function execute successfully",
+			name: "Test 1: When GetConfig executes successfully for provider",
 			args: args{
-				provider: "https://polygon-mumbai.g.alchemy.com/v2/-Re1lE3oDIVTWchuKMfRIECn0I",
+				configType: "provider",
+				provider:   "https://polygon-mumbai.g.alchemy.com/v2/-Re1lE3oDIVTWchuKMfRIECn0I",
 			},
 			want:    "https://polygon-mumbai.g.alchemy.com/v2/-Re1lE3oDIVTWchuKMfRIECn0I",
-			wantErr: nil,
+			wantErr: false,
 		},
 		{
 			name: "Test 2: When provider has prefix https",
 			args: args{
-				provider: "127.0.0.1:8545",
+				configType: "provider",
+				provider:   "127.0.0.1:8545",
 			},
 			want:    "127.0.0.1:8545",
-			wantErr: nil,
+			wantErr: false,
 		},
 		{
 			name: "Test 3: When there is an error in getting provider",
 			args: args{
+				configType:  "provider",
 				providerErr: errors.New("provider error"),
 			},
 			want:    "",
-			wantErr: errors.New("provider error"),
+			wantErr: true,
 		},
 		{
-			name: "Test 2: When provider is nil",
+			name: "Test 4: When provider is nil",
 			args: args{
-				provider: "",
+				configType: "provider",
+				provider:   "",
 			},
 			want:    "",
-			wantErr: nil,
+			wantErr: false,
 		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			flagSetUtilsMock := new(mocks.FlagSetInterface)
-			flagSetUtils = flagSetUtilsMock
-
-			flagSetUtilsMock.On("GetRootStringProvider").Return(tt.args.provider, tt.args.providerErr)
-			utils := &UtilsStruct{}
-
-			got, err := utils.GetProvider()
-			if got != tt.want {
-				t.Errorf("getProvider() got = %v, want %v", got, tt.want)
-			}
-			if err == nil || tt.wantErr == nil {
-				if err != tt.wantErr {
-					t.Errorf("Error for getProvider function, got = %v, want = %v", err, tt.wantErr)
-				}
-			} else {
-				if err.Error() != tt.wantErr.Error() {
-					t.Errorf("Error for getProvider function, got = %v, want = %v", err, tt.wantErr)
-				}
-			}
-		})
-	}
-}
-
-func TestGetWaitTime(t *testing.T) {
-	type args struct {
-		waitTime    int32
-		waitTimeErr error
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    int32
-		wantErr error
-	}{
 		{
-			name: "Test 1: When getWaitTime function executes successfully",
+			name: "Test 5: When GetConfig executes successfully for gasmultiplier",
 			args: args{
-				waitTime: 4,
+				configType:    "gasmultiplier",
+				gasMultiplier: "2",
 			},
-			want:    4,
-			wantErr: nil,
+			want:    "2",
+			wantErr: false,
 		},
 		{
-			name: "Test 2: When waitTime is -1",
+			name: "Test 6: When gasMultiplier is -1",
 			args: args{
-				waitTime: -1,
+				configType:    "gasmultiplier",
+				gasMultiplier: "-1",
 			},
-			want:    0,
-			wantErr: nil,
+			want:    "",
+			wantErr: false,
 		},
 		{
-			name: "Test 3: When there is an error in getting waitTime",
+			name: "Test 7: When there is an error in getting gasMultiplier",
 			args: args{
+				configType:       "gasmultiplier",
+				gasMultiplierErr: errors.New("gasMultiplier error"),
+			},
+			want:    "1",
+			wantErr: true,
+		},
+		{
+			name: "Test 8: When GetConfig executes successfully for buffer",
+			args: args{
+				configType:    "buffer",
+				bufferPercent: "20",
+			},
+			want:    "20",
+			wantErr: false,
+		},
+		{
+			name: "Test 9: When bufferPercent is 0",
+			args: args{
+				configType:    "buffer",
+				bufferPercent: "0",
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "Test 10: When there is an error in getting bufferPercent",
+			args: args{
+				configType:       "buffer",
+				bufferPercentErr: errors.New("bufferPercent error"),
+			},
+			want:    "30",
+			wantErr: true,
+		},
+		{
+			name: "Test 11: When GetConfig executes successfully for wait",
+			args: args{
+				configType: "wait",
+				waitTime:   "4",
+			},
+			want:    "4",
+			wantErr: false,
+		},
+		{
+			name: "Test 12: When waitTime is -1",
+			args: args{
+				configType: "wait",
+				waitTime:   "-1",
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "Test 13: When there is an error in getting waitTime",
+			args: args{
+				configType:  "wait",
 				waitTimeErr: errors.New("waitTime error"),
 			},
-			want:    3,
-			wantErr: errors.New("waitTime error"),
+			want:    "3",
+			wantErr: true,
+		},
+		{
+			name: "Test 14: When GetConfig executes successfully for gasPrice",
+			args: args{
+				configType: "gasprice",
+				gasPrice:   "1",
+			},
+			want:    "1",
+			wantErr: false,
+		},
+		{
+			name: "Test 15: When gasPrice is -1",
+			args: args{
+				configType: "gasprice",
+				gasPrice:   "-1",
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "Test 16: When there is an error in getting gasPrice",
+			args: args{
+				configType:  "gasprice",
+				gasPriceErr: errors.New("gasPrice error"),
+			},
+			want:    "0",
+			wantErr: true,
+		},
+		{
+			name: "Test 17: When GetConfig executes successfully for logLevel",
+			args: args{
+				configType: "logLevel",
+				logLevel:   "debug",
+			},
+			want:    "debug",
+			wantErr: false,
+		},
+		{
+			name: "Test 18: When logLevel is nil",
+			args: args{
+				configType: "logLevel",
+				logLevel:   "",
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "Test 19: When there is an error in getting logLevel",
+			args: args{
+				configType:  "logLevel",
+				logLevelErr: errors.New("logLevel error"),
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Test 20: When GetConfig executes successfully for gasLimit",
+			args: args{
+				configType: "gasLimit",
+				gasLimit:   "4",
+			},
+			want:    "4",
+			wantErr: false,
+		},
+		{
+			name: "Test 21: When gasLimit is -1",
+			args: args{
+				configType: "gasLimit",
+				gasLimit:   "-1",
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "Test 22: When there is an error in getting gasLimit",
+			args: args{
+				configType:  "gasLimit",
+				gasLimitErr: errors.New("gasLimit error"),
+			},
+			want:    "-1",
+			wantErr: true,
+		},
+		{
+			name: "Test 23: When configType does not match with any case",
+			args: args{
+				configType: "abc",
+			},
+			want:    "",
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -566,20 +433,22 @@ func TestGetWaitTime(t *testing.T) {
 			flagSetUtilsMock := new(mocks.FlagSetInterface)
 			flagSetUtils = flagSetUtilsMock
 
-			flagSetUtilsMock.On("GetRootInt32Wait").Return(tt.args.waitTime, tt.args.waitTimeErr)
-			utils := &UtilsStruct{}
-			got, err := utils.GetWaitTime()
-			if got != tt.want {
-				t.Errorf("getWaitTime() got = %v, want %v", got, tt.want)
+			flagSetUtilsMock.On("GetRootStringConfig", "provider").Return(tt.args.provider, tt.args.providerErr)
+			flagSetUtilsMock.On("GetRootStringConfig", "gasmultiplier").Return(tt.args.gasMultiplier, tt.args.gasMultiplierErr)
+			flagSetUtilsMock.On("GetRootStringConfig", "buffer").Return(tt.args.bufferPercent, tt.args.bufferPercentErr)
+			flagSetUtilsMock.On("GetRootStringConfig", "wait").Return(tt.args.waitTime, tt.args.waitTimeErr)
+			flagSetUtilsMock.On("GetRootStringConfig", "gasprice").Return(tt.args.gasPrice, tt.args.gasPriceErr)
+			flagSetUtilsMock.On("GetRootStringConfig", "logLevel").Return(tt.args.logLevel, tt.args.logLevelErr)
+			flagSetUtilsMock.On("GetRootStringConfig", "gasLimit").Return(tt.args.gasLimit, tt.args.gasLimitErr)
+
+			ut := &UtilsStruct{}
+			got, err := ut.GetConfig(tt.args.configType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
 			}
-			if err == nil || tt.wantErr == nil {
-				if err != tt.wantErr {
-					t.Errorf("Error for getWaitTime function, got = %v, want = %v", err, tt.wantErr)
-				}
-			} else {
-				if err.Error() != tt.wantErr.Error() {
-					t.Errorf("Error for getWaitTime function, got = %v, want = %v", err, tt.wantErr)
-				}
+			if got != tt.want {
+				t.Errorf("GetConfig() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -194,13 +194,6 @@ type FlagSetInterface interface {
 	GetFloat32GasLimit(flagSet *pflag.FlagSet) (float32, error)
 	GetStringLogLevel(flagSet *pflag.FlagSet) (string, error)
 	GetUint32BountyId(flagSet *pflag.FlagSet) (uint32, error)
-	GetRootStringProvider() (string, error)
-	GetRootFloat32GasMultiplier() (float32, error)
-	GetRootInt32Buffer() (int32, error)
-	GetRootInt32Wait() (int32, error)
-	GetRootInt32GasPrice() (int32, error)
-	GetRootStringLogLevel() (string, error)
-	GetRootFloat32GasLimit() (float32, error)
 	GetStringFrom(flagSet *pflag.FlagSet) (string, error)
 	GetStringTo(flagSet *pflag.FlagSet) (string, error)
 	GetStringAddress(flagSet *pflag.FlagSet) (string, error)
@@ -226,17 +219,11 @@ type FlagSetInterface interface {
 	GetStringExposeMetrics(flagSet *pflag.FlagSet) (string, error)
 	GetStringCertFile(flagSet *pflag.FlagSet) (string, error)
 	GetStringCertKey(flagSet *pflag.FlagSet) (string, error)
+	GetRootStringConfig(configType string) (string, error)
 }
 
 type UtilsCmdInterface interface {
 	SetConfig(flagSet *pflag.FlagSet) error
-	GetProvider() (string, error)
-	GetMultiplier() (float32, error)
-	GetWaitTime() (int32, error)
-	GetGasPrice() (int32, error)
-	GetLogLevel() (string, error)
-	GetGasLimit() (float32, error)
-	GetBufferPercent() (int32, error)
 	GetConfigData() (types.Configurations, error)
 	ExecuteClaimBounty(flagSet *pflag.FlagSet)
 	ClaimBounty(config types.Configurations, client *ethclient.Client, redeemBountyInput types.RedeemBountyInput) (common.Hash, error)
@@ -327,6 +314,7 @@ type UtilsCmdInterface interface {
 	ContractAddresses()
 	ResetDispute(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32)
 	StoreBountyId(client *ethclient.Client, account types.Account) error
+	GetConfig(configType string) (string, error)
 }
 
 type TransactionInterface interface {
@@ -347,6 +335,8 @@ type TimeInterface interface {
 
 type StringInterface interface {
 	ParseBool(str string) (bool, error)
+	ParseFloat(str string) (float64, error)
+	ParseInt(str string) (int64, error)
 }
 
 type AbiInterface interface {

--- a/cmd/mocks/flag_set_interface.go
+++ b/cmd/mocks/flag_set_interface.go
@@ -180,146 +180,20 @@ func (_m *FlagSetInterface) GetInt8Power(flagSet *pflag.FlagSet) (int8, error) {
 	return r0, r1
 }
 
-// GetRootFloat32GasLimit provides a mock function with given fields:
-func (_m *FlagSetInterface) GetRootFloat32GasLimit() (float32, error) {
-	ret := _m.Called()
-
-	var r0 float32
-	if rf, ok := ret.Get(0).(func() float32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(float32)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetRootFloat32GasMultiplier provides a mock function with given fields:
-func (_m *FlagSetInterface) GetRootFloat32GasMultiplier() (float32, error) {
-	ret := _m.Called()
-
-	var r0 float32
-	if rf, ok := ret.Get(0).(func() float32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(float32)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetRootInt32Buffer provides a mock function with given fields:
-func (_m *FlagSetInterface) GetRootInt32Buffer() (int32, error) {
-	ret := _m.Called()
-
-	var r0 int32
-	if rf, ok := ret.Get(0).(func() int32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int32)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetRootInt32GasPrice provides a mock function with given fields:
-func (_m *FlagSetInterface) GetRootInt32GasPrice() (int32, error) {
-	ret := _m.Called()
-
-	var r0 int32
-	if rf, ok := ret.Get(0).(func() int32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int32)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetRootInt32Wait provides a mock function with given fields:
-func (_m *FlagSetInterface) GetRootInt32Wait() (int32, error) {
-	ret := _m.Called()
-
-	var r0 int32
-	if rf, ok := ret.Get(0).(func() int32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int32)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetRootStringLogLevel provides a mock function with given fields:
-func (_m *FlagSetInterface) GetRootStringLogLevel() (string, error) {
-	ret := _m.Called()
+// GetRootStringConfig provides a mock function with given fields: configType
+func (_m *FlagSetInterface) GetRootStringConfig(configType string) (string, error) {
+	ret := _m.Called(configType)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(configType)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetRootStringProvider provides a mock function with given fields:
-func (_m *FlagSetInterface) GetRootStringProvider() (string, error) {
-	ret := _m.Called()
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(configType)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/cmd/mocks/string_interface.go
+++ b/cmd/mocks/string_interface.go
@@ -30,6 +30,48 @@ func (_m *StringInterface) ParseBool(str string) (bool, error) {
 	return r0, r1
 }
 
+// ParseFloat provides a mock function with given fields: str
+func (_m *StringInterface) ParseFloat(str string) (float64, error) {
+	ret := _m.Called(str)
+
+	var r0 float64
+	if rf, ok := ret.Get(0).(func(string) float64); ok {
+		r0 = rf(str)
+	} else {
+		r0 = ret.Get(0).(float64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(str)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ParseInt provides a mock function with given fields: str
+func (_m *StringInterface) ParseInt(str string) (int64, error) {
+	ret := _m.Called(str)
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(string) int64); ok {
+		r0 = rf(str)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(str)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 type mockConstructorTestingTNewStringInterface interface {
 	mock.TestingT
 	Cleanup(func())

--- a/cmd/mocks/utils_cmd_interface.go
+++ b/cmd/mocks/utils_cmd_interface.go
@@ -539,27 +539,6 @@ func (_m *UtilsCmdInterface) GetBountyIdFromEvents(client *ethclient.Client, blo
 	return r0, r1
 }
 
-// GetBufferPercent provides a mock function with given fields:
-func (_m *UtilsCmdInterface) GetBufferPercent() (int32, error) {
-	ret := _m.Called()
-
-	var r0 int32
-	if rf, ok := ret.Get(0).(func() int32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int32)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetCollectionIdPositionInBlock provides a mock function with given fields: client, leafId, proposedBlock
 func (_m *UtilsCmdInterface) GetCollectionIdPositionInBlock(client *ethclient.Client, leafId uint16, proposedBlock bindings.StructsBlock) *big.Int {
 	ret := _m.Called(client, leafId, proposedBlock)
@@ -588,6 +567,27 @@ func (_m *UtilsCmdInterface) GetCollectionList(client *ethclient.Client) error {
 	}
 
 	return r0
+}
+
+// GetConfig provides a mock function with given fields: configType
+func (_m *UtilsCmdInterface) GetConfig(configType string) (string, error) {
+	ret := _m.Called(configType)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(configType)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(configType)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // GetConfigData provides a mock function with given fields:
@@ -637,48 +637,6 @@ func (_m *UtilsCmdInterface) GetEpochAndState(client *ethclient.Client) (uint32,
 	}
 
 	return r0, r1, r2
-}
-
-// GetGasLimit provides a mock function with given fields:
-func (_m *UtilsCmdInterface) GetGasLimit() (float32, error) {
-	ret := _m.Called()
-
-	var r0 float32
-	if rf, ok := ret.Get(0).(func() float32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(float32)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetGasPrice provides a mock function with given fields:
-func (_m *UtilsCmdInterface) GetGasPrice() (int32, error) {
-	ret := _m.Called()
-
-	var r0 int32
-	if rf, ok := ret.Get(0).(func() int32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int32)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
 }
 
 // GetIteration provides a mock function with given fields: client, proposer, bufferPercent
@@ -771,69 +729,6 @@ func (_m *UtilsCmdInterface) GetLocalMediansData(client *ethclient.Client, accou
 	return r0, r1, r2, r3
 }
 
-// GetLogLevel provides a mock function with given fields:
-func (_m *UtilsCmdInterface) GetLogLevel() (string, error) {
-	ret := _m.Called()
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetMultiplier provides a mock function with given fields:
-func (_m *UtilsCmdInterface) GetMultiplier() (float32, error) {
-	ret := _m.Called()
-
-	var r0 float32
-	if rf, ok := ret.Get(0).(func() float32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(float32)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetProvider provides a mock function with given fields:
-func (_m *UtilsCmdInterface) GetProvider() (string, error) {
-	ret := _m.Called()
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetSalt provides a mock function with given fields: client, epoch
 func (_m *UtilsCmdInterface) GetSalt(client *ethclient.Client, epoch uint32) ([32]byte, error) {
 	ret := _m.Called(client, epoch)
@@ -922,27 +817,6 @@ func (_m *UtilsCmdInterface) GetStakerInfo(client *ethclient.Client, stakerId ui
 	}
 
 	return r0
-}
-
-// GetWaitTime provides a mock function with given fields:
-func (_m *UtilsCmdInterface) GetWaitTime() (int32, error) {
-	ret := _m.Called()
-
-	var r0 int32
-	if rf, ok := ret.Get(0).(func() int32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int32)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
 }
 
 // GiveSorted provides a mock function with given fields: client, blockManager, txnOpts, epoch, assetId, sortedStakers

--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -74,7 +74,11 @@ func (*UtilsStruct) Propose(client *ethclient.Client, config types.Configuration
 
 	log.Debugf("Biggest staker Id: %d Biggest stake: %s, Stake: %s, Staker Id: %d, Number of Stakers: %d, Salt: %s", biggestStakerId, biggestStake, staker.Stake, staker.Id, numStakers, hex.EncodeToString(salt[:]))
 
-	bufferPercent, err := cmdUtils.GetBufferPercent()
+	bufferPercentString, err := cmdUtils.GetConfig("buffer")
+	if err != nil {
+		return core.NilHash, err
+	}
+	bufferPercent, err := stringUtils.ParseInt(bufferPercentString)
 	if err != nil {
 		return core.NilHash, err
 	}
@@ -85,7 +89,7 @@ func (*UtilsStruct) Propose(client *ethclient.Client, config types.Configuration
 		NumberOfStakers: numStakers,
 		Salt:            salt,
 		Epoch:           epoch,
-	}, bufferPercent)
+	}, int32(bufferPercent))
 
 	log.Debug("Iteration: ", iteration)
 
@@ -184,12 +188,16 @@ func (*UtilsStruct) GetBiggestStakeAndId(client *ethclient.Client, address strin
 	var biggestStakerId uint32
 	biggestStake := big.NewInt(0)
 
-	bufferPercent, err := cmdUtils.GetBufferPercent()
+	bufferPercentString, err := cmdUtils.GetConfig("buffer")
+	if err != nil {
+		return nil, 0, err
+	}
+	bufferPercent, err := stringUtils.ParseInt(bufferPercentString)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	stateRemainingTime, err := utilsInterface.GetRemainingTimeOfCurrentState(client, bufferPercent)
+	stateRemainingTime, err := utilsInterface.GetRemainingTimeOfCurrentState(client, int32(bufferPercent))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,12 +14,12 @@ import (
 
 var (
 	Provider           string
-	GasMultiplier      float32
-	BufferPercent      int32
-	WaitTime           int32
-	GasPrice           int32
+	GasMultiplier      string
+	BufferPercent      string
+	WaitTime           string
+	GasPrice           string
 	LogLevel           string
-	GasLimitMultiplier float32
+	GasLimitMultiplier string
 	LogFile            string
 )
 
@@ -54,12 +54,12 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVarP(&Provider, "provider", "p", "", "provider name")
-	rootCmd.PersistentFlags().Float32VarP(&GasMultiplier, "gasmultiplier", "g", -1, "gas multiplier value")
-	rootCmd.PersistentFlags().Int32VarP(&BufferPercent, "buffer", "b", 0, "buffer percent")
-	rootCmd.PersistentFlags().Int32VarP(&WaitTime, "wait", "w", -1, "wait time")
-	rootCmd.PersistentFlags().Int32VarP(&GasPrice, "gasprice", "", -1, "gas price")
+	rootCmd.PersistentFlags().StringVarP(&GasMultiplier, "gasmultiplier", "g", "-1", "gas multiplier value")
+	rootCmd.PersistentFlags().StringVarP(&BufferPercent, "buffer", "b", "0", "buffer percent")
+	rootCmd.PersistentFlags().StringVarP(&WaitTime, "wait", "w", "-1", "wait time")
+	rootCmd.PersistentFlags().StringVarP(&GasPrice, "gasprice", "", "-1", "gas price")
 	rootCmd.PersistentFlags().StringVarP(&LogLevel, "logLevel", "", "", "log level")
-	rootCmd.PersistentFlags().Float32VarP(&GasLimitMultiplier, "gasLimit", "", -1, "gas limit percentage increase")
+	rootCmd.PersistentFlags().StringVarP(&GasLimitMultiplier, "gasLimit", "", "-1", "gas limit percentage increase")
 	rootCmd.PersistentFlags().StringVarP(&LogFile, "logFile", "", "", "name of log file")
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -749,6 +749,10 @@ func (assetManagerUtils AssetManagerUtils) UpdateCollection(client *ethclient.Cl
 	return assetManager.UpdateCollection(opts, collectionId, tolerance, aggregationMethod, power, jobIds)
 }
 
+func (flagSetUtils FLagSetUtils) GetRootStringConfig(configType string) (string, error) {
+	return rootCmd.PersistentFlags().GetString(configType)
+}
+
 //This function returns the provider in string
 func (flagSetUtils FLagSetUtils) GetStringProvider(flagSet *pflag.FlagSet) (string, error) {
 	return flagSet.GetString("provider")
@@ -787,41 +791,6 @@ func (flagSetUtils FLagSetUtils) GetFloat32GasLimit(flagSet *pflag.FlagSet) (flo
 //This function returns BountyId in Uint32
 func (flagSetUtils FLagSetUtils) GetUint32BountyId(flagSet *pflag.FlagSet) (uint32, error) {
 	return flagSet.GetUint32("bountyId")
-}
-
-//This function returns the provider of root in string
-func (flagSetUtils FLagSetUtils) GetRootStringProvider() (string, error) {
-	return rootCmd.PersistentFlags().GetString("provider")
-}
-
-//This function returns the gas multiplier of root in float32
-func (flagSetUtils FLagSetUtils) GetRootFloat32GasMultiplier() (float32, error) {
-	return rootCmd.PersistentFlags().GetFloat32("gasmultiplier")
-}
-
-//This function returns the buffer of root in Int32
-func (flagSetUtils FLagSetUtils) GetRootInt32Buffer() (int32, error) {
-	return rootCmd.PersistentFlags().GetInt32("buffer")
-}
-
-//This function returns the wait of root in Int32
-func (flagSetUtils FLagSetUtils) GetRootInt32Wait() (int32, error) {
-	return rootCmd.PersistentFlags().GetInt32("wait")
-}
-
-//This function returns the gas price of root in Int32
-func (flagSetUtils FLagSetUtils) GetRootInt32GasPrice() (int32, error) {
-	return rootCmd.PersistentFlags().GetInt32("gasprice")
-}
-
-//This function returns the log level of root in string
-func (flagSetUtils FLagSetUtils) GetRootStringLogLevel() (string, error) {
-	return rootCmd.PersistentFlags().GetString("logLevel")
-}
-
-//This function returns the gas limit of root in Float32
-func (flagSetUtils FLagSetUtils) GetRootFloat32GasLimit() (float32, error) {
-	return rootCmd.PersistentFlags().GetFloat32("gasLimit")
 }
 
 //This function returns the from in string
@@ -984,6 +953,14 @@ func (t TimeUtils) Sleep(duration time.Duration) {
 //This function is used to parse the bool
 func (s StringUtils) ParseBool(str string) (bool, error) {
 	return strconv.ParseBool(str)
+}
+
+func (s StringUtils) ParseFloat(str string) (float64, error) {
+	return strconv.ParseFloat(str, 32)
+}
+
+func (s StringUtils) ParseInt(str string) (int64, error) {
+	return strconv.ParseInt(str, 10, 32)
 }
 
 //This function is used for unpacking

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -749,6 +749,7 @@ func (assetManagerUtils AssetManagerUtils) UpdateCollection(client *ethclient.Cl
 	return assetManager.UpdateCollection(opts, collectionId, tolerance, aggregationMethod, power, jobIds)
 }
 
+//This function returns the config of configType in form of string
 func (flagSetUtils FLagSetUtils) GetRootStringConfig(configType string) (string, error) {
 	return rootCmd.PersistentFlags().GetString(configType)
 }
@@ -955,10 +956,12 @@ func (s StringUtils) ParseBool(str string) (bool, error) {
 	return strconv.ParseBool(str)
 }
 
+//This functon is used to parse the float
 func (s StringUtils) ParseFloat(str string) (float64, error) {
 	return strconv.ParseFloat(str, 32)
 }
 
+//This function is used to parse the int
 func (s StringUtils) ParseInt(str string) (int64, error) {
 	return strconv.ParseInt(str, 10, 32)
 }

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -497,12 +497,15 @@ func (*UtilsStruct) GetLastProposedEpoch(client *ethclient.Client, blockNumber *
 	}
 	epochLastProposed := uint32(0)
 
-	bufferPercent, err := cmdUtils.GetBufferPercent()
+	bufferPercentString, err := cmdUtils.GetConfig("buffer")
 	if err != nil {
 		return 0, err
 	}
-
-	stateRemainingTime, err := utilsInterface.GetRemainingTimeOfCurrentState(client, bufferPercent)
+	bufferPercent, err := stringUtils.ParseInt(bufferPercentString)
+	if err != nil {
+		return 0, err
+	}
+	stateRemainingTime, err := utilsInterface.GetRemainingTimeOfCurrentState(client, int32(bufferPercent))
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
# Description

- Function name GetConfig() added which taked string as input and returns the desired config values.
- Other function for config are been removed
-  Tests modified according to the changes

Fixes #835 