### PR TITLE
Replaced common.Hash{0x00} with core.NilHash

### DIFF
--- a/cmd/addStake.go
+++ b/cmd/addStake.go
@@ -86,7 +86,7 @@ func (*UtilsStruct) ExecuteStake(flagSet *pflag.FlagSet) {
 func (*UtilsStruct) StakeCoins(txnArgs types.TransactionOptions) (common.Hash, error) {
 	epoch, err := razorUtils.GetEpoch(txnArgs.Client)
 	if err != nil {
-		return common.Hash{0x00}, err
+		return core.NilHash, err
 	}
 
 	log.Info("Sending stake transactions...")
@@ -97,7 +97,7 @@ func (*UtilsStruct) StakeCoins(txnArgs types.TransactionOptions) (common.Hash, e
 	txnOpts := razorUtils.GetTxnOpts(txnArgs)
 	tx, err := stakeManagerUtils.Stake(txnArgs.Client, txnOpts, epoch, txnArgs.Amount)
 	if err != nil {
-		return common.Hash{0x00}, err
+		return core.NilHash, err
 	}
 	log.Info("Txn Hash: ", transactionUtils.Hash(tx).Hex())
 	return transactionUtils.Hash(tx), nil

--- a/cmd/approve.go
+++ b/cmd/approve.go
@@ -13,11 +13,11 @@ func (*UtilsStruct) Approve(txnArgs types.TransactionOptions) (common.Hash, erro
 	opts := razorUtils.GetOptions()
 	allowance, err := tokenManagerUtils.Allowance(txnArgs.Client, &opts, common.HexToAddress(txnArgs.AccountAddress), common.HexToAddress(core.StakeManagerAddress))
 	if err != nil {
-		return common.Hash{0x00}, err
+		return core.NilHash, err
 	}
 	if allowance.Cmp(txnArgs.Amount) >= 0 {
 		log.Debug("Sufficient allowance, no need to increase")
-		return common.Hash{0x00}, nil
+		return core.NilHash, nil
 	} else {
 		log.Info("Sending Approve transaction...")
 		txnArgs.ContractAddress = core.RAZORAddress
@@ -27,7 +27,7 @@ func (*UtilsStruct) Approve(txnArgs types.TransactionOptions) (common.Hash, erro
 		txnOpts := razorUtils.GetTxnOpts(txnArgs)
 		txn, err := tokenManagerUtils.Approve(txnArgs.Client, txnOpts, common.HexToAddress(core.StakeManagerAddress), txnArgs.Amount)
 		if err != nil {
-			return common.Hash{0x00}, err
+			return core.NilHash, err
 		}
 		log.Info("Txn Hash: ", transactionUtils.Hash(txn))
 		return transactionUtils.Hash(txn), nil

--- a/cmd/approve_test.go
+++ b/cmd/approve_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"math/big"
 	"razor/cmd/mocks"
+	"razor/core"
 	"razor/core/types"
 	"testing"
 )
@@ -79,7 +80,7 @@ func TestApprove(t *testing.T) {
 				approveError:    nil,
 				hash:            common.BigToHash(big.NewInt(1)),
 			},
-			want:    common.Hash{0x00},
+			want:    core.NilHash,
 			wantErr: nil,
 		},
 		{
@@ -101,7 +102,7 @@ func TestApprove(t *testing.T) {
 				approveError:    nil,
 				hash:            common.BigToHash(big.NewInt(1)),
 			},
-			want:    common.Hash{0x00},
+			want:    core.NilHash,
 			wantErr: errors.New("allowance error"),
 		},
 
@@ -124,7 +125,7 @@ func TestApprove(t *testing.T) {
 				approveError:    errors.New("approve error"),
 				hash:            common.BigToHash(big.NewInt(1)),
 			},
-			want:    common.Hash{0},
+			want:    core.NilHash,
 			wantErr: errors.New("approve error"),
 		},
 	}

--- a/cmd/claimBounty.go
+++ b/cmd/claimBounty.go
@@ -140,7 +140,7 @@ func (*UtilsStruct) ClaimBounty(config types.Configurations, client *ethclient.C
 	epoch, err := razorUtils.GetEpoch(txnArgs.Client)
 	if err != nil {
 		log.Error("Error in getting epoch: ", err)
-		return common.Hash{0x00}, err
+		return core.NilHash, err
 	}
 
 	callOpts := razorUtils.GetOptions()

--- a/cmd/delegate.go
+++ b/cmd/delegate.go
@@ -92,7 +92,7 @@ func (*UtilsStruct) Delegate(txnArgs types.TransactionOptions, stakerId uint32) 
 	log.Info("Sending Delegate transaction...")
 	txn, err := stakeManagerUtils.Delegate(txnArgs.Client, delegationTxnOpts, stakerId, txnArgs.Amount)
 	if err != nil {
-		return common.Hash{0x00}, err
+		return core.NilHash, err
 	}
 	log.Infof("Transaction hash: %s", transactionUtils.Hash(txn))
 	return transactionUtils.Hash(txn), nil


### PR DESCRIPTION
# Description

Replaced common.Hash{0x00} with core.NilHash everywhere/
Fixes #845
