### PR TITLE
Replacing path.join with filepath.join

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"path"
+	"path/filepath"
 	razorAccounts "razor/accounts"
 	"razor/utils"
 )
@@ -44,7 +44,7 @@ func (*UtilsStruct) Create(password string) (accounts.Account, error) {
 		log.Error("Error in fetching .razor directory")
 		return accounts.Account{Address: common.Address{0x00}}, err
 	}
-	keystorePath := path.Join(razorPath, "keystore_files")
+	keystorePath := filepath.Join(razorPath, "keystore_files")
 	account := razorAccounts.AccountUtilsInterface.CreateAccount(keystorePath, password)
 	return account, nil
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	pathPkg "path"
+	"path/filepath"
 	"razor/path"
 	"razor/utils"
 	"strings"
@@ -49,7 +49,7 @@ func (*UtilsStruct) ImportAccount() (accounts.Account, error) {
 		return accounts.Account{Address: common.Address{0x00}}, err
 	}
 
-	keystoreDir := pathPkg.Join(razorPath, "keystore_files")
+	keystoreDir := filepath.Join(razorPath, "keystore_files")
 	if _, err := path.OSUtilsInterface.Stat(keystoreDir); path.OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := path.OSUtilsInterface.Mkdir(keystoreDir, 0700)
 		if mkdirErr != nil {

--- a/cmd/listAccounts.go
+++ b/cmd/listAccounts.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	pathPkg "path"
+	"path/filepath"
 	"razor/utils"
 )
 
@@ -42,7 +42,7 @@ func (*UtilsStruct) ListAccounts() ([]accounts.Account, error) {
 		return nil, err
 	}
 
-	keystorePath := pathPkg.Join(path, "keystore_files")
+	keystorePath := filepath.Join(path, "keystore_files")
 	return keystoreUtils.Accounts(keystorePath), nil
 }
 

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -9,7 +9,7 @@ import (
 	"math/big"
 	"os"
 	"os/signal"
-	"path"
+	"path/filepath"
 	"razor/accounts"
 	"razor/core"
 	"razor/core/types"
@@ -498,7 +498,7 @@ func (*UtilsStruct) CalculateSecret(account types.Account, epoch uint32) ([]byte
 	if err != nil {
 		return nil, errors.New("Error in fetching .razor directory: " + err.Error())
 	}
-	keystorePath := path.Join(razorPath, "keystore_files")
+	keystorePath := filepath.Join(razorPath, "keystore_files")
 	signedData, err := accounts.AccountUtilsInterface.SignData(hash, account, keystorePath)
 	if err != nil {
 		return nil, errors.New("Error in signing the data: " + err.Error())

--- a/path/path.go
+++ b/path/path.go
@@ -3,7 +3,7 @@ package path
 
 import (
 	"os"
-	pathPkg "path"
+	"path/filepath"
 )
 
 //This function returns the default path
@@ -12,7 +12,7 @@ func (PathUtils) GetDefaultPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defaultPath := pathPkg.Join(home, ".razor")
+	defaultPath := filepath.Join(home, ".razor")
 	if _, err := OSUtilsInterface.Stat(defaultPath); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(defaultPath, 0700)
 		if mkdirErr != nil {
@@ -28,7 +28,7 @@ func (PathUtils) GetLogFilePath(fileName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	filePath := pathPkg.Join(razorPath, fileName+".log")
+	filePath := filepath.Join(razorPath, fileName+".log")
 	f, err := OSUtilsInterface.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return "", err
@@ -43,7 +43,7 @@ func (PathUtils) GetConfigFilePath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return pathPkg.Join(razorPath, "razor.yaml"), nil
+	return filepath.Join(razorPath, "razor.yaml"), nil
 }
 
 //This function returns the job file path
@@ -52,7 +52,7 @@ func (PathUtils) GetJobFilePath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	filePath := pathPkg.Join(razorPath, "assets.json")
+	filePath := filepath.Join(razorPath, "assets.json")
 	return filePath, nil
 }
 
@@ -62,7 +62,7 @@ func (PathUtils) GetCommitDataFileName(address string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dataFileDir := pathPkg.Join(razorDir, "data_files")
+	dataFileDir := filepath.Join(razorDir, "data_files")
 	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
 		if mkdirErr != nil {
@@ -70,7 +70,7 @@ func (PathUtils) GetCommitDataFileName(address string) (string, error) {
 		}
 	}
 
-	return pathPkg.Join(dataFileDir, address+"_CommitData.json"), nil
+	return filepath.Join(dataFileDir, address+"_CommitData.json"), nil
 }
 
 //This function returns the file name of propose data file
@@ -79,14 +79,14 @@ func (PathUtils) GetProposeDataFileName(address string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dataFileDir := pathPkg.Join(razorDir, "data_files")
+	dataFileDir := filepath.Join(razorDir, "data_files")
 	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
 		if mkdirErr != nil {
 			return "", mkdirErr
 		}
 	}
-	return pathPkg.Join(dataFileDir, address+"_proposedData.json"), nil
+	return filepath.Join(dataFileDir, address+"_proposedData.json"), nil
 }
 
 //This function returns the file name of dispute data file
@@ -95,12 +95,12 @@ func (PathUtils) GetDisputeDataFileName(address string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dataFileDir := pathPkg.Join(razorDir, "data_files")
+	dataFileDir := filepath.Join(razorDir, "data_files")
 	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
 		if mkdirErr != nil {
 			return "", mkdirErr
 		}
 	}
-	return pathPkg.Join(dataFileDir, address+"_disputeData.json"), nil
+	return filepath.Join(dataFileDir, address+"_disputeData.json"), nil
 }


### PR DESCRIPTION
# Description

Changed different occurrences of `path.join` to `filepath.join` for using os specific path seperators.

There are more occurrences than mentioned in the issue. I hope that it is okay if I replaced every occurrence in the stated files.

Fixes #884 

## Type of change

Please delete options that are not relevant.

- [x] code cleanup

# How Has This Been Tested?

- [x] Unit-Testing
- [x] IDE static code analysis
- [x] checking for passing build

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules