### PR TITLE
vote as goroutine

### DIFF
--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -304,6 +304,7 @@ type UtilsCmdInterface interface {
 	HandleBlock(client *ethclient.Client, account types.Account, blockNumber *big.Int, config types.Configurations, rogueData types.Rogue)
 	ExecuteVote(flagSet *pflag.FlagSet)
 	Vote(ctx context.Context, config types.Configurations, client *ethclient.Client, rogueData types.Rogue, account types.Account) error
+	GetVoteConcurrently(ctx context.Context, config types.Configurations, client *ethclient.Client, rogueData types.Rogue, account types.Account, done chan bool, quit chan bool) error
 	HandleExit()
 	ExecuteListAccounts(flagSet *pflag.FlagSet)
 	ClaimCommission(flagSet *pflag.FlagSet)

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -304,7 +304,7 @@ type UtilsCmdInterface interface {
 	HandleBlock(client *ethclient.Client, account types.Account, blockNumber *big.Int, config types.Configurations, rogueData types.Rogue)
 	ExecuteVote(flagSet *pflag.FlagSet)
 	Vote(ctx context.Context, config types.Configurations, client *ethclient.Client, rogueData types.Rogue, account types.Account) error
-	GetVoteConcurrently(ctx context.Context, config types.Configurations, client *ethclient.Client, rogueData types.Rogue, account types.Account, done chan bool, quit chan bool) error
+	GetVoteConcurrently(ctx context.Context, config types.Configurations, client *ethclient.Client, rogueData types.Rogue, account types.Account, quit chan bool) error
 	HandleExit()
 	ExecuteListAccounts(flagSet *pflag.FlagSet)
 	ClaimCommission(flagSet *pflag.FlagSet)

--- a/cmd/mocks/utils_cmd_interface.go
+++ b/cmd/mocks/utils_cmd_interface.go
@@ -833,6 +833,20 @@ func (_m *UtilsCmdInterface) GetStakerInfo(client *ethclient.Client, stakerId ui
 	return r0
 }
 
+// GetVoteConcurrently provides a mock function with given fields: ctx, config, client, rogueData, account, done, quit
+func (_m *UtilsCmdInterface) GetVoteConcurrently(ctx context.Context, config types.Configurations, client *ethclient.Client, rogueData types.Rogue, account types.Account, done chan bool, quit chan bool) error {
+	ret := _m.Called(ctx, config, client, rogueData, account, done, quit)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, types.Configurations, *ethclient.Client, types.Rogue, types.Account, chan bool, chan bool) error); ok {
+		r0 = rf(ctx, config, client, rogueData, account, done, quit)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GiveSorted provides a mock function with given fields: client, blockManager, txnOpts, epoch, assetId, sortedStakers
 func (_m *UtilsCmdInterface) GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []*big.Int) {
 	_m.Called(client, blockManager, txnOpts, epoch, assetId, sortedStakers)

--- a/cmd/mocks/utils_cmd_interface.go
+++ b/cmd/mocks/utils_cmd_interface.go
@@ -833,13 +833,13 @@ func (_m *UtilsCmdInterface) GetStakerInfo(client *ethclient.Client, stakerId ui
 	return r0
 }
 
-// GetVoteConcurrently provides a mock function with given fields: ctx, config, client, rogueData, account, done, quit
-func (_m *UtilsCmdInterface) GetVoteConcurrently(ctx context.Context, config types.Configurations, client *ethclient.Client, rogueData types.Rogue, account types.Account, done chan bool, quit chan bool) error {
-	ret := _m.Called(ctx, config, client, rogueData, account, done, quit)
+// GetVoteConcurrently provides a mock function with given fields: ctx, config, client, rogueData, account, quit
+func (_m *UtilsCmdInterface) GetVoteConcurrently(ctx context.Context, config types.Configurations, client *ethclient.Client, rogueData types.Rogue, account types.Account, quit chan bool) error {
+	ret := _m.Called(ctx, config, client, rogueData, account, quit)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.Configurations, *ethclient.Client, types.Rogue, types.Account, chan bool, chan bool) error); ok {
-		r0 = rf(ctx, config, client, rogueData, account, done, quit)
+	if rf, ok := ret.Get(0).(func(context.Context, types.Configurations, *ethclient.Client, types.Rogue, types.Account, chan bool) error); ok {
+		r0 = rf(ctx, config, client, rogueData, account, quit)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -105,20 +105,18 @@ func (*UtilsStruct) HandleExit() {
 
 //This function handles all the states of voting
 func (*UtilsStruct) Vote(ctx context.Context, config types.Configurations, client *ethclient.Client, rogueData types.Rogue, account types.Account) error {
-	var done = make(chan bool)
 	var quit = make(chan bool)
 	go func() {
-		err := cmdUtils.GetVoteConcurrently(ctx, config, client, rogueData, account, done, quit)
+		err := cmdUtils.GetVoteConcurrently(ctx, config, client, rogueData, account, quit)
 		if err != nil {
 			return
 		}
 	}()
 	<-quit
-	<-done
 	return nil
 }
 
-func (*UtilsStruct) GetVoteConcurrently(ctx context.Context, config types.Configurations, client *ethclient.Client, rogueData types.Rogue, account types.Account, done chan bool, quit chan bool) error {
+func (*UtilsStruct) GetVoteConcurrently(ctx context.Context, config types.Configurations, client *ethclient.Client, rogueData types.Rogue, account types.Account, quit chan bool) error {
 	header, err := utils.UtilsInterface.GetLatestBlockWithRetry(client)
 	utils.CheckError("Error in getting block: ", err)
 	for {
@@ -139,8 +137,6 @@ func (*UtilsStruct) GetVoteConcurrently(ctx context.Context, config types.Config
 
 		}
 	}
-	done <- true
-	return nil
 }
 
 var (


### PR DESCRIPTION
# Description

- Handled vote as a go-routine.
- Created a channel quit for quitting case.
- Used a single go-routine to handle the voting concurrently.

Fixes #861 