### PR TITLE
replaced path.join with filepath.join

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"path"
+	"path/filepath"
 	razorAccounts "razor/accounts"
 	"razor/utils"
 )
@@ -44,7 +44,7 @@ func (*UtilsStruct) Create(password string) (accounts.Account, error) {
 		log.Error("Error in fetching .razor directory")
 		return accounts.Account{Address: common.Address{0x00}}, err
 	}
-	keystorePath := path.Join(razorPath, "keystore_files")
+	keystorePath := filepath.Join(razorPath, "keystore_files")
 	account := razorAccounts.AccountUtilsInterface.CreateAccount(keystorePath, password)
 	return account, nil
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	pathPkg "path"
+	"path/filepath"
 	"razor/path"
 	"razor/utils"
 	"strings"
@@ -53,7 +53,7 @@ func (*UtilsStruct) ImportAccount() (accounts.Account, error) {
 		log.Error("Error in parsing private key")
 		return accounts.Account{Address: common.Address{0x00}}, err
 	}
-	keystoreDir := pathPkg.Join(razorPath, "keystore_files")
+	keystoreDir := filepath.Join(razorPath, "keystore_files")
 	if _, err := path.OSUtilsInterface.Stat(keystoreDir); path.OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := path.OSUtilsInterface.Mkdir(keystoreDir, 0700)
 		if mkdirErr != nil {

--- a/cmd/listAccounts.go
+++ b/cmd/listAccounts.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	pathPkg "path"
+	"path/filepath"
 	"razor/utils"
 )
 
@@ -42,7 +42,7 @@ func (*UtilsStruct) ListAccounts() ([]accounts.Account, error) {
 		return nil, err
 	}
 
-	keystorePath := pathPkg.Join(path, "keystore_files")
+	keystorePath := filepath.Join(path, "keystore_files")
 	return keystoreUtils.Accounts(keystorePath), nil
 }
 

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -9,7 +9,7 @@ import (
 	"math/big"
 	"os"
 	"os/signal"
-	"path"
+	"path/filepath"
 	"razor/accounts"
 	"razor/core"
 	"razor/core/types"
@@ -312,7 +312,7 @@ func (*UtilsStruct) InitiateCommit(client *ethclient.Client, config types.Config
 	if err != nil {
 		return err
 	}
-	keystorePath := path.Join(razorPath, "keystore_files")
+	keystorePath := filepath.Join(razorPath, "keystore_files")
 
 	_, secret, err := cmdUtils.CalculateSecret(account, epoch, keystorePath, core.ChainId)
 	if err != nil {
@@ -425,7 +425,7 @@ func (*UtilsStruct) InitiateReveal(client *ethclient.Client, config types.Config
 	if err != nil {
 		return err
 	}
-	keystorePath := path.Join(razorPath, "keystore_files")
+	keystorePath := filepath.Join(razorPath, "keystore_files")
 
 	signature, _, err := cmdUtils.CalculateSecret(account, epoch, keystorePath, core.ChainId)
 	if err != nil {

--- a/path/path.go
+++ b/path/path.go
@@ -3,7 +3,7 @@ package path
 
 import (
 	"os"
-	pathPkg "path"
+	"path/filepath"
 	"razor/core"
 )
 
@@ -13,7 +13,7 @@ func (PathUtils) GetDefaultPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defaultPath := pathPkg.Join(home, core.DefaultPathName)
+	defaultPath := filepath.Join(home, core.DefaultPathName)
 	if _, err := OSUtilsInterface.Stat(defaultPath); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(defaultPath, 0700)
 		if mkdirErr != nil {
@@ -29,7 +29,7 @@ func (PathUtils) GetLogFilePath(fileName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defaultPath := pathPkg.Join(razorPath, core.LogFile)
+	defaultPath := filepath.Join(razorPath, core.LogFile)
 	if _, err := OSUtilsInterface.Stat(defaultPath); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(defaultPath, 0700)
 		if mkdirErr != nil {
@@ -37,7 +37,7 @@ func (PathUtils) GetLogFilePath(fileName string) (string, error) {
 		}
 	}
 
-	logFilepath := pathPkg.Join(defaultPath, fileName+".log")
+	logFilepath := filepath.Join(defaultPath, fileName+".log")
 	f, err := OSUtilsInterface.OpenFile(logFilepath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return "", err
@@ -52,7 +52,7 @@ func (PathUtils) GetConfigFilePath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return pathPkg.Join(razorPath, core.ConfigFile), nil
+	return filepath.Join(razorPath, core.ConfigFile), nil
 }
 
 //This function returns the job file path
@@ -61,7 +61,7 @@ func (PathUtils) GetJobFilePath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	filePath := pathPkg.Join(razorPath, core.AssetsDataFile)
+	filePath := filepath.Join(razorPath, core.AssetsDataFile)
 	return filePath, nil
 }
 
@@ -71,7 +71,7 @@ func (PathUtils) GetCommitDataFileName(address string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dataFileDir := pathPkg.Join(razorDir, core.DataFileDirectory)
+	dataFileDir := filepath.Join(razorDir, core.DataFileDirectory)
 	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
 		if mkdirErr != nil {
@@ -79,7 +79,7 @@ func (PathUtils) GetCommitDataFileName(address string) (string, error) {
 		}
 	}
 
-	return pathPkg.Join(dataFileDir, address+core.CommitDataFile), nil
+	return filepath.Join(dataFileDir, address+core.CommitDataFile), nil
 }
 
 //This function returns the file name of propose data file
@@ -88,14 +88,14 @@ func (PathUtils) GetProposeDataFileName(address string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dataFileDir := pathPkg.Join(razorDir, core.DataFileDirectory)
+	dataFileDir := filepath.Join(razorDir, core.DataFileDirectory)
 	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
 		if mkdirErr != nil {
 			return "", mkdirErr
 		}
 	}
-	return pathPkg.Join(dataFileDir, address+core.ProposeDataFile), nil
+	return filepath.Join(dataFileDir, address+core.ProposeDataFile), nil
 }
 
 //This function returns the file name of dispute data file
@@ -104,12 +104,12 @@ func (PathUtils) GetDisputeDataFileName(address string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dataFileDir := pathPkg.Join(razorDir, core.DataFileDirectory)
+	dataFileDir := filepath.Join(razorDir, core.DataFileDirectory)
 	if _, err := OSUtilsInterface.Stat(dataFileDir); OSUtilsInterface.IsNotExist(err) {
 		mkdirErr := OSUtilsInterface.Mkdir(dataFileDir, 0700)
 		if mkdirErr != nil {
 			return "", mkdirErr
 		}
 	}
-	return pathPkg.Join(dataFileDir, address+core.DisputeDataFile), nil
+	return filepath.Join(dataFileDir, address+core.DisputeDataFile), nil
 }


### PR DESCRIPTION
# Description

I accidentally closed the other PR because of the issue of the unverified commits. (#892 ) Sorry for that

Changed different occurrences of path.join to filepath.join for using os specific path seperators.

There are more occurrences than mentioned in the issue. I hope that it is okay if I replaced every occurrence in the stated files.

Fixes #884 

## Type of change

Please delete options that are not relevant.

- [x] code cleanup

# How Has This Been Tested?

- [x] Unit-Testing
- [x] IDE static code analysis
- [x] checking for passing build

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes