### PR TITLE
Hotfix-giveSorted

### DIFF
--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -286,7 +286,7 @@ type UtilsCmdInterface interface {
 	GetSortedRevealedValues(client *ethclient.Client, blockNumber *big.Int, epoch uint32) (*types.RevealedDataMaps, error)
 	GetIteration(client *ethclient.Client, proposer types.ElectedProposer, bufferPercent int32) int
 	Propose(client *ethclient.Client, config types.Configurations, account types.Account, staker bindings.StructsStaker, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) error
-	GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []*big.Int)
+	GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnArgs *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []*big.Int) error
 	GetLocalMediansData(client *ethclient.Client, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) (types.ProposeFileData, error)
 	CheckDisputeForIds(client *ethclient.Client, transactionOpts types.TransactionOptions, epoch uint32, blockIndex uint8, idsInProposedBlock []uint16, revealedCollectionIds []uint16) (*Types.Transaction, error)
 	Dispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockIndex uint8, proposedBlock bindings.StructsBlock, leafId uint16, sortedValues []*big.Int) error

--- a/cmd/mocks/utils_cmd_interface.go
+++ b/cmd/mocks/utils_cmd_interface.go
@@ -926,8 +926,17 @@ func (_m *UtilsCmdInterface) GetWaitTime() (int32, error) {
 }
 
 // GiveSorted provides a mock function with given fields: client, blockManager, txnOpts, epoch, assetId, sortedStakers
-func (_m *UtilsCmdInterface) GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []*big.Int) {
-	_m.Called(client, blockManager, txnOpts, epoch, assetId, sortedStakers)
+func (_m *UtilsCmdInterface) GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []*big.Int) error {
+	ret := _m.Called(client, blockManager, txnOpts, epoch, assetId, sortedStakers)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, *bindings.BlockManager, *bind.TransactOpts, uint32, uint16, []*big.Int) error); ok {
+		r0 = rf(client, blockManager, txnOpts, epoch, assetId, sortedStakers)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // HandleBlock provides a mock function with given fields: client, account, blockNumber, config, rogueData

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -967,8 +967,8 @@ func (c CryptoUtils) HexToECDSA(hexKey string) (*ecdsa.PrivateKey, error) {
 }
 
 //This function is used to give the sorted Ids
-func (*UtilsStruct) GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []*big.Int) {
-	GiveSorted(client, blockManager, txnOpts, epoch, assetId, sortedStakers)
+func (*UtilsStruct) GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []*big.Int) error {
+	return GiveSorted(client, blockManager, txnOpts, epoch, assetId, sortedStakers)
 }
 
 //This function is used to write config as


### PR DESCRIPTION
# Description

- Reset Dispute is only after `FinalizeDispute`, removed from other dispute types.
- `ResetDispute` called irrespective of `FinalizeDispute` Txn status.

Fixes #911
