### PR TITLE
V1 logs

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -69,6 +69,7 @@ func (*UtilsStruct) HandleCommitState(client *ethclient.Client, epoch uint32, se
 				return types.CommitData{}, err
 			}
 			if rogueData.IsRogue && utils.Contains(rogueData.RogueMode, "commit") {
+				log.Warn("YOU ARE COMMITTING VALUES IN ROGUE MODE, THIS CAN INCUR PENALTIES!")
 				collectionData = razorUtils.GetRogueRandomValue(100000)
 			}
 			log.Debugf("Data of collection %d:%s", collectionId, collectionData)

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -51,7 +51,7 @@ func (*UtilsStruct) HandleCommitState(client *ethclient.Client, epoch uint32, se
 	if err != nil {
 		return types.CommitData{}, err
 	}
-
+	log.Debugf("Number of active collections: %d", numActiveCollections)
 	assignedCollections, seqAllottedCollections, err := utils.UtilsInterface.GetAssignedCollections(client, numActiveCollections, seed)
 	if err != nil {
 		return types.CommitData{}, err

--- a/cmd/dispute.go
+++ b/cmd/dispute.go
@@ -49,6 +49,10 @@ func (*UtilsStruct) HandleDispute(client *ethclient.Client, config types.Configu
 	revealedCollectionIds := locallyCalculatedData.RevealedCollectionIds
 	revealedDataMaps := locallyCalculatedData.RevealedDataMaps
 
+	log.Debug("Local Medians data:", medians)
+	log.Debug("Revealed collection ids:", revealedCollectionIds)
+	log.Debug("Local revealed data maps:", revealedDataMaps)
+
 	randomSortedProposedBlockIds := utils.UtilsInterface.Shuffle(sortedProposedBlockIds) //shuffles the sortedProposedBlockIds array
 	transactionOptions := types.TransactionOptions{
 		Client:         client,
@@ -57,6 +61,7 @@ func (*UtilsStruct) HandleDispute(client *ethclient.Client, config types.Configu
 		ChainId:        core.ChainId,
 		Config:         config,
 	}
+	log.Debug("Shuffled sorted proposed blocks: ", randomSortedProposedBlockIds)
 
 	for _, blockId := range randomSortedProposedBlockIds {
 		proposedBlock, err := razorUtils.GetProposedBlock(client, epoch, uint32(blockId))
@@ -73,7 +78,7 @@ func (*UtilsStruct) HandleDispute(client *ethclient.Client, config types.Configu
 			log.Error("Block is not present in SortedProposedBlockIds array")
 			continue
 		}
-
+		log.Debugf("Block Index: %d", blockIndex)
 		// Biggest staker dispute
 		if proposedBlock.BiggestStake.Cmp(biggestStake) != 0 && proposedBlock.Valid {
 			log.Debug("Biggest Stake in proposed block: ", proposedBlock.BiggestStake)
@@ -119,6 +124,7 @@ func (*UtilsStruct) HandleDispute(client *ethclient.Client, config types.Configu
 
 			//If dispute happens, then storing the bountyId into disputeData file
 			if WaitForBlockCompletionErr == nil {
+				log.Debug("Storing bounty id in dispute data file")
 				err = cmdUtils.StoreBountyId(client, account)
 				if err != nil {
 					log.Error(err)

--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -46,6 +46,7 @@ func (*UtilsStruct) Propose(client *ethclient.Client, config types.Configuration
 	)
 
 	if rogueData.IsRogue && utils.Contains(rogueData.RogueMode, "biggestStakerId") {
+		log.Warn("YOU ARE PROPOSING IN ROGUE MODE, THIS CAN INCUR PENALTIES!")
 		// If staker is going rogue with biggestStakerId than we do biggestStakerId = smallestStakerId
 		smallestStake, smallestStakerId, smallestStakerErr := cmdUtils.GetSmallestStakeAndId(client, epoch)
 		if smallestStakerErr != nil {

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -66,7 +66,7 @@ func (*UtilsStruct) ExecuteVote(flagSet *pflag.FlagSet) {
 	}
 
 	if rogueData.IsRogue {
-		log.Warn("You are running vote in rogue mode, this can incur penalties!")
+		log.Warn("YOU ARE RUNNING VOTE IN ROGUE MODE, THIS CAN INCUR PENALTIES!")
 	}
 
 	client := razorUtils.ConnectToClient(config.Provider)
@@ -387,6 +387,8 @@ func (*UtilsStruct) InitiateReveal(client *ethclient.Client, config types.Config
 	if err != nil {
 		return errors.New("Error in fetching last reveal: " + err.Error())
 	}
+	log.Debugf("Last reveal was at epoch %d", lastReveal)
+
 	if lastReveal >= epoch {
 		log.Debugf("Since last reveal was at epoch: %d, won't reveal again in epoch: %d", lastReveal, epoch)
 		return nil
@@ -396,7 +398,6 @@ func (*UtilsStruct) InitiateReveal(client *ethclient.Client, config types.Config
 		log.Error(err)
 		return err
 	}
-	log.Debug("Epoch last revealed: ", lastReveal)
 
 	if _commitData.AssignedCollections == nil && _commitData.SeqAllottedCollections == nil && _commitData.Leaves == nil {
 		fileName, err := razorUtils.GetCommitDataFileName(account.Address)
@@ -404,6 +405,7 @@ func (*UtilsStruct) InitiateReveal(client *ethclient.Client, config types.Config
 			log.Error("Error in getting file name to save committed data: ", err)
 			return err
 		}
+		log.Debugf("Getting committed data from file %s", fileName)
 		committedDataFromFile, err := razorUtils.ReadFromCommitJsonFile(fileName)
 		if err != nil {
 			log.Errorf("Error in getting committed data from file %s: %t", fileName, err)
@@ -418,6 +420,7 @@ func (*UtilsStruct) InitiateReveal(client *ethclient.Client, config types.Config
 		_commitData.Leaves = committedDataFromFile.Leaves
 	}
 	if rogueData.IsRogue && utils.Contains(rogueData.RogueMode, "reveal") {
+		log.Warn("YOU ARE REVEALING VALUES IN ROGUE MODE, THIS CAN INCUR PENALTIES!")
 		var rogueCommittedData []*big.Int
 		for i := 0; i < len(_commitData.Leaves); i++ {
 			rogueCommittedData = append(rogueCommittedData, razorUtils.GetRogueRandomValue(10000000))
@@ -435,6 +438,10 @@ func (*UtilsStruct) InitiateReveal(client *ethclient.Client, config types.Config
 	if err != nil {
 		return err
 	}
+	log.Debug("Assigned Collections: ", _commitData.AssignedCollections)
+	log.Debug("SeqAllottedCollections: ", _commitData.SeqAllottedCollections)
+	log.Debug("Leaves: ", _commitData.Leaves)
+
 	revealTxn, err := cmdUtils.Reveal(client, config, account, epoch, _commitData, signature)
 	if err != nil {
 		return errors.New("Reveal error: " + err.Error())
@@ -465,6 +472,7 @@ func (*UtilsStruct) InitiatePropose(client *ethclient.Client, config types.Confi
 	if err != nil {
 		return errors.New("Error in fetching last proposal: " + err.Error())
 	}
+	log.Debugf("Last propose was in epoch %d", lastProposal)
 	if lastProposal >= epoch {
 		log.Debugf("Since last propose was at epoch: %d, won't propose again in epoch: %d", epoch, lastProposal)
 		return nil

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -114,13 +114,13 @@ func (*UtilsStruct) Vote(ctx context.Context, config types.Configurations, clien
 		case <-ctx.Done():
 			return nil
 		default:
-			log.Debugf("Header value: ", header.Number)
+			log.Debugf("Header value: %d", header.Number)
 			latestHeader, err := utils.UtilsInterface.GetLatestBlockWithRetry(client)
 			if err != nil {
 				log.Error("Error in fetching block: ", err)
 				continue
 			}
-			log.Debugf("Latest header value: ", latestHeader.Number)
+			log.Debugf("Latest header value: %d", latestHeader.Number)
 			if latestHeader.Number.Cmp(header.Number) != 0 {
 				header = latestHeader
 				cmdUtils.HandleBlock(client, account, latestHeader.Number, config, rogueData)

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -64,6 +64,11 @@ func (*UtilsStruct) ExecuteVote(flagSet *pflag.FlagSet) {
 		IsRogue:   isRogue,
 		RogueMode: rogueMode,
 	}
+
+	if rogueData.IsRogue {
+		log.Warn("You are running vote in rogue mode, this can incur penalties!")
+	}
+
 	client := razorUtils.ConnectToClient(config.Provider)
 
 	account := types.Account{Address: address, Password: password}
@@ -109,11 +114,13 @@ func (*UtilsStruct) Vote(ctx context.Context, config types.Configurations, clien
 		case <-ctx.Done():
 			return nil
 		default:
+			log.Debugf("Header value: ", header.Number)
 			latestHeader, err := utils.UtilsInterface.GetLatestBlockWithRetry(client)
 			if err != nil {
 				log.Error("Error in fetching block: ", err)
 				continue
 			}
+			log.Debugf("Latest header value: ", latestHeader.Number)
 			if latestHeader.Number.Cmp(header.Number) != 0 {
 				header = latestHeader
 				cmdUtils.HandleBlock(client, account, latestHeader.Number, config, rogueData)
@@ -200,25 +207,31 @@ func (*UtilsStruct) HandleBlock(client *ethclient.Client, account types.Account,
 
 	switch state {
 	case 0:
+		log.Debugf("Starting commit...")
 		err := cmdUtils.InitiateCommit(client, config, account, epoch, stakerId, rogueData)
 		if err != nil {
 			log.Error(err)
 			break
 		}
 	case 1:
+		log.Debugf("Starting reveal...")
 		err := cmdUtils.InitiateReveal(client, config, account, epoch, staker, rogueData)
 		if err != nil {
 			log.Error(err)
 			break
 		}
 	case 2:
+		log.Debugf("Starting propose...")
 		err := cmdUtils.InitiatePropose(client, config, account, epoch, staker, blockNumber, rogueData)
 		if err != nil {
 			log.Error(err)
 			break
 		}
 	case 3:
+		log.Debugf("Last verification: %d", lastVerification)
 		if lastVerification >= epoch {
+			log.Debugf("Last verification (%d) is greater or equal to current epoch (%d)", lastVerification, epoch)
+			log.Debugf("Won't dispute now")
 			break
 		}
 
@@ -231,6 +244,7 @@ func (*UtilsStruct) HandleBlock(client *ethclient.Client, account types.Account,
 		lastVerification = epoch
 
 		if utilsInterface.IsFlagPassed("autoClaimBounty") {
+			log.Debugf("Automatically claiming bounty")
 			err = cmdUtils.HandleClaimBounty(client, config, account)
 			if err != nil {
 				log.Error(err)
@@ -239,6 +253,8 @@ func (*UtilsStruct) HandleBlock(client *ethclient.Client, account types.Account,
 		}
 
 	case 4:
+		log.Debugf("Last verification: %d", lastVerification)
+		log.Debugf("Block confirmed: %d", blockConfirmed)
 		if lastVerification == epoch && blockConfirmed < epoch {
 			txn, err := cmdUtils.ClaimBlockReward(types.TransactionOptions{
 				Client:          client,
@@ -287,14 +303,18 @@ func (*UtilsStruct) InitiateCommit(client *ethclient.Client, config types.Config
 		log.Error("Error in getting minimum stake amount: ", err)
 		return err
 	}
+	log.Debugf("Minimum stake amount: %d", minStakeAmount)
 	if stakedAmount.Cmp(minStakeAmount) < 0 {
 		log.Error("Stake is below minimum required. Kindly add stake to continue voting.")
 		return nil
 	}
+
 	lastCommit, err := razorUtils.GetEpochLastCommitted(client, stakerId)
 	if err != nil {
 		return errors.New("Error in fetching last commit: " + err.Error())
 	}
+	log.Debugf("Epoch last committed: %d", lastCommit)
+
 	if lastCommit >= epoch {
 		log.Debugf("Cannot commit in epoch %d because last committed epoch is %d", epoch, lastCommit)
 		return nil
@@ -304,7 +324,7 @@ func (*UtilsStruct) InitiateCommit(client *ethclient.Client, config types.Config
 		return err
 	}
 	keystorePath := path.Join(razorPath, "keystore_files")
-
+	log.Debugf("Keystore file path: %s", keystorePath)
 	_, secret, err := cmdUtils.CalculateSecret(account, epoch, keystorePath, core.ChainId)
 	if err != nil {
 		return err
@@ -472,7 +492,7 @@ func (*UtilsStruct) CalculateSecret(account types.Account, epoch uint32, keystor
 	}
 	hash := solsha3.SoliditySHA3([]string{"address", "uint32", "uint256", "string"}, []interface{}{common.HexToAddress(account.Address), epoch, chainId, "razororacle"})
 	ethHash := utils.SignHash(hash)
-
+	log.Debug("Hash generated for secret")
 	signedData, err := accounts.AccountUtilsInterface.SignData(ethHash, account, keystorePath)
 	if err != nil {
 		return nil, nil, errors.New("Error in signing the data: " + err.Error())
@@ -489,6 +509,7 @@ func (*UtilsStruct) CalculateSecret(account types.Account, epoch uint32, keystor
 	}
 
 	secret := crypto.Keccak256(signedData)
+	log.Debug("Secret generated.")
 	return signedData, secret, nil
 }
 


### PR DESCRIPTION
# Description

Added debug logs at many places during vote, to make it easier for devs to debug.


* Logs added for rogue mode, to warn users that rogue mode is running.
* Logs added for `numActiveCollections` while committing data.
* Logs added for displaying local median values while disputing data.
* Logs added for displaying actual blockIndex while disputing block
* Logs added for displaying the current block number and the latest block number every time the vote command executes `GetLatestHeader`.
* Logs added for displaying when did the last verification occur.
* Logs added for displaying when was the last block confirmed.
* Logs added for minimum stake amount
* Logs added for displaying when did the last commit occur.
* Logs added for displaying when did the last reveal occur.
* Logs added for displaying keystore file path.
* Logs added for displaying assigned collections, and leaf values during reveal.
* Logs added for notifying that secret generation has begun.

Closes #916 
