### PR TITLE
fix: prevent panic in stakerInfo by passing correct *bind.CallOpts type

### DIFF
--- a/utils/struct-utils.go
+++ b/utils/struct-utils.go
@@ -528,7 +528,7 @@ func (s StakeManagerStruct) StakerInfo(client *ethclient.Client, stakerId uint32
 func (s StakeManagerStruct) GetMaturity(client *ethclient.Client, age uint32) (uint16, error) {
 	stakeManager, opts := UtilsInterface.GetStakeManagerWithOpts(client)
 	index := age / 10000
-	returnedValues := InvokeFunctionWithTimeout(stakeManager, "Maturities", opts, big.NewInt(int64(index)))
+	returnedValues := InvokeFunctionWithTimeout(stakeManager, "Maturities", &opts, big.NewInt(int64(index)))
 	returnedError := CheckIfAnyError(returnedValues)
 	if returnedError != nil {
 		return 0, returnedError


### PR DESCRIPTION
### **User description**
# Description

This PR fixes a runtime panic in the stakerInfo command caused by passing an incorrect argument type to contract binding methods when invoking them via reflection.

The contract bindings expect `*bind.CallOpts`, but the code was passing `bind.CallOpts` as a value, resulting in a reflection panic at runtime.

Fixes #1277

# How Has This Been Tested?

Reproduced the panic locally using:

```
razor stakerInfo --stakerId <id>
```

Verified that the command now completes successfully without panicking and confirmed correct staker information is returned


___

### **PR Type**
Bug fix


___

### **Description**
- Fix runtime panic in GetMaturity by passing pointer to bind.CallOpts

- Contract bindings expect *bind.CallOpts, not value type

- Corrects reflection invocation argument type mismatch


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GetMaturity function"] -->|"passes opts to InvokeFunctionWithTimeout"| B["InvokeFunctionWithTimeout"]
  B -->|"before: opts value type"| C["❌ Reflection panic"]
  B -->|"after: &opts pointer type"| D["✓ Correct execution"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>struct-utils.go</strong><dd><code>Pass pointer to bind.CallOpts in GetMaturity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/struct-utils.go

<ul><li>Changed <code>opts</code> to <code>&opts</code> in InvokeFunctionWithTimeout call within <br>GetMaturity method<br> <li> Passes pointer to bind.CallOpts instead of value type to match <br>contract binding expectations<br> <li> Fixes runtime panic that occurred when invoking the function via <br>reflection</ul>


</details>


  </td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1278/files#diff-ca2310f6e3742503ce2754ab1cdb68eb5aade94a26a538afd39c356457f14797">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

